### PR TITLE
add support for configuring plugin via ini settings mechanism; some refactoring to argument validation logic

### DIFF
--- a/pytest_impacted/plugin.py
+++ b/pytest_impacted/plugin.py
@@ -1,11 +1,13 @@
+from functools import partial
+
 import pytest
-from pytest import UsageError
+from pytest import Config, Parser, UsageError
 
 from pytest_impacted.api import matches_impacted_tests, get_impacted_tests
 from pytest_impacted.git import GitMode
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser):
     """pytest hook to add command line options.
 
     This is called before any tests are collected.
@@ -15,26 +17,44 @@ def pytest_addoption(parser):
     group.addoption(
         "--impacted",
         action="store_true",
-        default=False,
+        default=None,
         dest="impacted",
         help="Run only tests impacted by the chosen git state.",
     )
+    parser.addini(
+        "impacted",
+        help="default value for --impacted",
+        default=False,
+    )
+
     group.addoption(
         "--impacted-module",
-        action="store",
         default=None,
         dest="impacted_module",
+        metavar="MODULE",
         help="Module name to check for impacted tests.",
     )
+    parser.addini(
+        "impacted_module",
+        help="default value for --impacted-module",
+        default=None,
+    )
+
     group.addoption(
         "--impacted-git-mode",
         action="store",
         dest="impacted_git_mode",
         choices=GitMode.__members__.values(),
-        default=GitMode.UNSTAGED,
+        default=None,
         nargs="?",
         help="Git reference for computing impacted files.",
     )
+    parser.addini(
+        "impacted_git_mode",
+        help="default value for --impacted-git-mode",
+        default=GitMode.UNSTAGED,
+    )
+
     group.addoption(
         "--impacted-base-branch",
         action="store",
@@ -42,6 +62,12 @@ def pytest_addoption(parser):
         dest="impacted_base_branch",
         help="Git reference for computing impacted files when running in 'branch' git mode.",
     )
+    parser.addini(
+        "impacted_base_branch",
+        help="default value for --impacted-base-branch",
+        default=None,
+    )
+
     group.addoption(
         "--impacted-tests-dir",
         action="store",
@@ -49,33 +75,40 @@ def pytest_addoption(parser):
         dest="impacted_tests_dir",
         help="Directory containing the unit-test files. If not specified, tests will only be found under namespace module directory.",
     )
+    parser.addini(
+        "impacted_tests_dir",
+        help="default value for --impacted-tests-dir",
+        default=None,
+    )
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config):
     """pytest hook to configure the plugin.
 
     This is called after the command line options have been parsed.
 
     """
-    if config.getoption("impacted"):
-        if not config.getoption("impacted_module"):
-            # If the impacted option is set, we need to check if there is a module specified.
-            raise UsageError(
-                "No module specified. Please specify a module using --impacted-module."
-            )
-
-        if config.getoption(
-            "impacted_git_mode"
-        ) == GitMode.BRANCH and not config.getoption("impacted_base_branch"):
-            # If the git mode is branch, we need to check if there is a base branch specified.
-            raise UsageError(
-                "No base branch specified. Please specify a base branch using --impacted-base-branch."
-            )
+    validate_config(config)
 
     config.addinivalue_line(
         "markers",
         "impacted(state): mark test as impacted by the state of the git repository",
     )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_header(config: Config) -> list[str]:
+    """Add pytest-impacted config to pytest header."""
+    get_option = partial(get_option_from_config, config)
+    header = [
+        f"impacted_module={get_option('impacted_module')}",
+        f"impacted_git_mode={get_option('impacted_git_mode')}",
+        f"impacted_base_branch={get_option('impacted_base_branch')}",
+        f"impacted_tests_dir={get_option('impacted_tests_dir')}",
+    ]
+    return [
+        "pytest-impacted: " + ", ".join(header),
+    ]
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -85,14 +118,15 @@ def pytest_collection_modifyitems(session, config, items):
     they are run.
 
     """
-    impacted = config.getoption("impacted")
+    get_option = partial(get_option_from_config, config)
+    impacted = get_option("impacted")
     if not impacted:
         return
 
-    ns_module = config.getoption("impacted_module")
-    impacted_git_mode = config.getoption("impacted_git_mode")
-    impacted_base_branch = config.getoption("impacted_base_branch")
-    impacted_tests_dir = config.getoption("impacted_tests_dir")
+    ns_module = get_option("impacted_module")
+    impacted_git_mode = get_option("impacted_git_mode")
+    impacted_base_branch = get_option("impacted_base_branch")
+    impacted_tests_dir = get_option("impacted_tests_dir")
     root_dir = config.rootdir
 
     impacted_tests = get_impacted_tests(
@@ -120,3 +154,35 @@ def pytest_collection_modifyitems(session, config, items):
             # Mark the item as skipped if it is not impacted. This will be used to
             # let pytest know to skip the test.
             item.add_marker(pytest.mark.skip)
+
+
+def get_option_from_config(config: Config, name: str) -> str | None:
+    """Get an option from the config.
+
+    If the option is not set, return the default value from the ini file if present.
+
+    """
+    return config.getoption(name) or config.getini(name)
+
+
+def validate_config(config: Config):
+    get_option = partial(get_option_from_config, config)
+    if get_option("impacted"):
+        if not get_option("impacted_module"):
+            # If the impacted option is set, we need to check if there is a module specified.
+            raise UsageError(
+                "No module specified. Please specify a module using --impacted-module."
+            )
+        if not get_option("impacted_git_mode"):
+            # If the impacted option is set, we need to check if there is a git mode specified.
+            raise UsageError(
+                "No git mode specified. Please specify a git mode using --impacted-git-mode."
+            )
+
+        if get_option("impacted_git_mode") == GitMode.BRANCH and not get_option(
+            "impacted_base_branch"
+        ):
+            # If the git mode is branch, we need to check if there is a base branch specified.
+            raise UsageError(
+                "No base branch specified. Please specify a base branch using --impacted-base-branch."
+            )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,97 @@
+import pytest
+from _pytest.config.argparsing import Parser
+from pytest_impacted.plugin import (
+    pytest_addoption,
+    pytest_configure,
+    pytest_report_header,
+    validate_config,
+)
+from pytest_impacted.git import GitMode
+
+
+def test_pytest_addoption():
+    """Test that the plugin adds the correct command line options."""
+    parser = Parser()
+    pytest_addoption(parser)
+
+    # Check that the impacted group exists
+    group = parser.getgroup("impacted")
+    assert group is not None
+
+    # Check that all options are added
+    options = {opt.dest for opt in group.options}
+    expected_options = {
+        "impacted",
+        "impacted_module",
+        "impacted_git_mode",
+        "impacted_base_branch",
+        "impacted_tests_dir",
+    }
+    assert options == expected_options
+
+
+def test_pytest_configure(pytestconfig):
+    """Test that the plugin configures correctly."""
+    pytest_configure(pytestconfig)
+
+    # Check that the marker is added
+    markers = pytestconfig.getini("markers")
+    assert (
+        "impacted(state): mark test as impacted by the state of the git repository"
+        in markers
+    )
+
+
+def test_pytest_report_header(pytestconfig):
+    """Test that the plugin adds the correct header information."""
+    pytestconfig.option.impacted_module = "test_module"
+    pytestconfig.option.impacted_git_mode = GitMode.UNSTAGED
+    pytestconfig.option.impacted_base_branch = "main"
+    pytestconfig.option.impacted_tests_dir = "tests"
+
+    header = pytest_report_header(pytestconfig)
+    assert len(header) == 1
+    assert "pytest-impacted:" in header[0]
+    assert "impacted_module=test_module" in header[0]
+    assert "impacted_git_mode=unstaged" in header[0]
+    assert "impacted_base_branch=main" in header[0]
+    assert "impacted_tests_dir=tests" in header[0]
+
+
+def test_validate_config_valid(pytestconfig):
+    """Test that valid configuration passes validation."""
+    pytestconfig.option.impacted = True
+    pytestconfig.option.impacted_module = "test_module"
+    pytestconfig.option.impacted_git_mode = GitMode.UNSTAGED
+    validate_config(pytestconfig)  # Should not raise
+
+
+def test_validate_config_missing_module(pytestconfig):
+    """Test that validation fails when module is missing."""
+    pytestconfig.option.impacted = True
+    pytestconfig.option.impacted_module = None
+    pytestconfig._inicache["impacted_module"] = None
+    pytestconfig.option.impacted_git_mode = GitMode.UNSTAGED
+    with pytest.raises(pytest.UsageError, match="No module specified"):
+        validate_config(pytestconfig)
+
+
+def test_validate_config_missing_git_mode(pytestconfig):
+    """Test that validation fails when git mode is missing."""
+    pytestconfig.option.impacted = True
+    pytestconfig.option.impacted_module = "test_module"
+    pytestconfig.option.impacted_git_mode = None
+    pytestconfig._inicache["impacted_git_mode"] = None
+    with pytest.raises(pytest.UsageError, match="No git mode specified"):
+        validate_config(pytestconfig)
+
+
+def test_validate_config_branch_mode_missing_base(pytestconfig):
+    """Test that validation fails when branch mode is used without base branch."""
+    pytestconfig.option.impacted = True
+    pytestconfig.option.impacted_module = "test_module"
+    pytestconfig.option.impacted_git_mode = GitMode.BRANCH
+    pytestconfig.option.impacted_base_branch = None
+    pytestconfig._inicache["impacted_base_branch"] = None
+    with pytest.raises(pytest.UsageError, match="No base branch specified"):
+        validate_config(pytestconfig)


### PR DESCRIPTION
- add support for configuring plugin via pytest ini settings mechanism
- some refactoring to argument validation logic in `plugin.py` to support ini-based config and slightly better testability + slightly better typing
- announce configuration settings as a header via `pytest_report_header`