### PR TITLE
support for the R<score> and C<score> git diff name-status format with a score

### DIFF
--- a/pytest_impacted/git.py
+++ b/pytest_impacted/git.py
@@ -74,8 +74,20 @@ class Change:
         """Create a Change from a git diff.
 
         Input is the output of `git diff --name-status`.
+        For rename and copy operations, the name will contain both source and destination
+        paths separated by a tab.
 
         """
+        if status is not None and status.startswith(("R", "C")):
+            # For rename/copy operations, split the name into source and destination
+            if name is not None and "\t" in name:
+                a_path, b_path = name.split("\t", 1)
+                return cls(
+                    a_path=a_path,
+                    b_path=b_path,
+                    status=GitStatus.from_git_diff_name_status(status),
+                )
+
         return cls(
             a_path=name,
             b_path=None,

--- a/pytest_impacted/git.py
+++ b/pytest_impacted/git.py
@@ -32,6 +32,19 @@ class GitStatus(StrEnum):
     UNKNOWN = "X"
     PAIRING_BROKEN = "B"
 
+    @classmethod
+    def from_git_diff_name_status(cls, status: str) -> "GitStatus":
+        """Create a GitStatus from a git diff name status."""
+        match status:
+            case _ as status if status.startswith("R") and status[1:].isdigit():
+                # git diff --name-status output may report <X><score> for renamed files
+                return cls.RENAMED
+            case _ as status if status.startswith("C") and status[1:].isdigit():
+                # git diff --name-status output may report <X><score> for copied files
+                return cls.COPIED
+            case _:
+                return cls(status)
+
 
 class Change:
     """A change to a git repository file."""
@@ -66,7 +79,9 @@ class Change:
         return cls(
             a_path=name,
             b_path=None,
-            status=GitStatus(status) if status is not None else None,
+            status=GitStatus.from_git_diff_name_status(status)
+            if status is not None
+            else None,
         )
 
 


### PR DESCRIPTION
See [git diff](https://git-scm.com/docs/diff-options#:~:text=Select%20only%20files%20that%20are,their%20pairing%20Broken%20(%20B%20).) docs.

- Add support for the R<score> and C<score> `git diff --name-status` format
- Add support for copy / move operations where the line format includes source and destination file names
- Add unit-test coverage