### PR TITLE
feature/ah ruff settings and fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.15.0
+  rev: v1.16.0
   hooks:
     - id: mypy
 - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.9
+  rev: v0.11.12
   hooks:
     # Run the linter.
     - id: ruff

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When using this plugin in CI, it is sometimes desirable to generate the list of 
 and then invoke running these in a separate step later in the CI pipeline. This can be achieved with the `impacted-tests` CLI included with the plugin, which supports the same arguments
 as the plugin itself:
 
-    $ impacted-tests --ns-module=<my_root_module_name> --git-mode=branch --base-branch=main > impacted_tests.txt
+    $ impacted-tests --module=<my_root_module_name> --git-mode=branch --base-branch=main > impacted_tests.txt
 
 In some later step of your CI can then run:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ You can install "pytest-impacted" via `pip`from `PyPI`:
 
 ## Usage
 
+### Local unstaged changes
+
 Use as a pytest plugin. Examples for invocation:
 
     $ pytest --impacted --impacted-git-mode=unstaged --impacted-module=<my_root_module_name>
@@ -48,16 +50,32 @@ Use as a pytest plugin. Examples for invocation:
 This will run all unit-tests impacted by changes to files which have unstaged
 modifications in the current active git repository.
 
+
+### Changes committed to current git branch
+
     $ pytest --impacted --impacted-git-mode=branch --impacted-base-branch=main --impacted-module=<my_root_module_name>
 
 this will run all unit-tests impacted by changes to files which have been
 modified via any existing commits to the current active branch, as compared to
 the base branch passed in the `--impacted-base-branch` parameter.
 
+### External tests directory
+
 As another common use case, In some projects the tests directory exists outside of the namespace package. In those cases you can use the `--impacted-tests-dir` option to make sure those test files are included in the dependency tree and correctly considered for impact analysis:
 
     $ pytest --impacted --impacted-git-mode=unstaged --impacted-module=<my_root_module_name> --impacted-tests-dir=tests/
 
+### CI Integration
+
+When using this plugin in CI, it is sometimes desirable to generate the list of impacted test files in one stage where we have access to the git CLI (and perhaps required credentials),
+and then invoke running these in a separate step later in the CI pipeline. This can be achieved with the `impacted-tests` CLI included with the plugin, which supports the same arguments
+as the plugin itself:
+
+    $ impacted-tests --ns-module=<my_root_module_name> --git-mode=branch --base-branch=main > impacted_tests.txt
+
+In some later step of your CI can then run:
+
+    $ pytest @impacted_tests.txt
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,15 @@ target-version = "py311"
 quote-style = "double"
 
 [tool.ruff.lint]
-# Enable pycodestyle (`E`), Pyflakes (`F`), and isort (`I`) codes by default.
-select = ["E", "F", "I"]
+ignore = [
+  "T201",
+]
+
+select = [
+    "B",  # flake8-bugbear
+    "E",  # pycodestyle
+    "F",  # Pyflakes
+    "I",  # isort
+    "PERF",  # perflint
+    "T",  # flake8-debugger
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,4 +64,13 @@ dev = [
 namespace_packages = true
 ignore_missing_imports = true
 
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.format]
+quote-style = "double"
+
 [tool.ruff.lint]
+# Enable pycodestyle (`E`), Pyflakes (`F`), and isort (`I`) codes by default.
+select = ["E", "F", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ select = [
     "B",  # flake8-bugbear
     "E",  # pycodestyle
     "F",  # Pyflakes
+    "G",  # flake8-logging-format
     "I",  # isort
     "PERF",  # perflint
     "T",  # flake8-debugger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,11 @@ quote-style = "double"
 
 [tool.ruff.lint]
 ignore = [
-  "T201",
+    "T201",  # allow print statement
 ]
 
 select = [
+    "A",  # flake8-builtins
     "B",  # flake8-bugbear
     "E",  # pycodestyle
     "F",  # Pyflakes

--- a/pytest_impacted/api.py
+++ b/pytest_impacted/api.py
@@ -1,17 +1,17 @@
 """Matchers used for pattern matching and unit-tests."""
 
-import sys
 import logging
+import sys
 from pathlib import Path
 
 from pytest_impacted.display import notify, warn
 from pytest_impacted.git import GitMode, find_impacted_files_in_repo
+from pytest_impacted.graph import build_dep_tree, resolve_impacted_tests
 from pytest_impacted.traversal import (
     path_to_package_name,
     resolve_files_to_modules,
     resolve_modules_to_files,
 )
-from pytest_impacted.graph import build_dep_tree, resolve_impacted_tests
 
 
 def matches_impacted_tests(item_path: str, *, impacted_tests: list[str]) -> bool:
@@ -41,9 +41,7 @@ def get_impacted_tests(
         # so that we can import the tests_dir as a module.
         tests_dir_path = Path(tests_dir).resolve().parent
         if str(tests_dir_path) not in sys.path:
-            logging.debug(
-                "Adding tests_dir parent directory to sys.path: %s", tests_dir_path
-            )
+            logging.debug("Adding tests_dir parent directory to sys.path: %s", tests_dir_path)
             sys.path.insert(0, str(tests_dir_path))
         tests_package = path_to_package_name(tests_dir)
 
@@ -65,9 +63,7 @@ def get_impacted_tests(
         session,
     )
 
-    impacted_modules = resolve_files_to_modules(
-        impacted_files, ns_module=ns_module, tests_package=tests_package
-    )
+    impacted_modules = resolve_files_to_modules(impacted_files, ns_module=ns_module, tests_package=tests_package)
     if not impacted_modules:
         notify(
             f"No impacted Python modules detected. Impacted files were: {impacted_files}",
@@ -80,7 +76,8 @@ def get_impacted_tests(
     impacted_test_modules = resolve_impacted_tests(impacted_modules, dep_tree)
     if not impacted_test_modules:
         warn(
-            f"No unit-test modules impacted by the changes could be detected. Impacted Python modules were: {impacted_modules}",
+            "No unit-test modules impacted by the changes could be detected. "
+            + f"Impacted Python modules were: {impacted_modules}",
             session,
         )
         return None
@@ -88,7 +85,8 @@ def get_impacted_tests(
     impacted_test_files = resolve_modules_to_files(impacted_test_modules)
     if not impacted_test_files:
         warn(
-            f"No unit-test file paths impacted by the changes could be found. impacted test modules were: {impacted_test_modules}",
+            "No unit-test file paths impacted by the changes could be found. "
+            + f"impacted test modules were: {impacted_test_modules}",
             session,
         )
         return None

--- a/pytest_impacted/cli.py
+++ b/pytest_impacted/cli.py
@@ -1,7 +1,9 @@
 """CLI entrypoints for pytest-impacted."""
 
-import click
 import logging
+import sys
+
+import click
 from rich.logging import RichHandler
 
 from pytest_impacted.api import get_impacted_tests
@@ -15,6 +17,7 @@ def configure_logging(verbose: bool) -> None:
         format="%(funcName)-20s | %(message)s",
         datefmt="[%x]",
         handlers=[RichHandler(rich_tracebacks=True, markup=True)],
+        stream=sys.stderr,
     )
 
 
@@ -36,17 +39,20 @@ def configure_logging(verbose: bool) -> None:
 @click.option(
     "--tests-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    help="Directory containing the unit-test files. If not specified, tests will only be found under namespace module directory.",
+    help=(
+        "Directory containing the unit-test files. If not specified, "
+        + "tests will only be found under namespace module directory."
+    ),
 )
 @click.option("--verbose", is_flag=True, help="Verbose output.")
 def impacted_tests_cli(git_mode, base_branch, root_dir, ns_module, tests_dir, verbose):
     """CLI entrypoint for impacted-tests console script."""
-    click.echo("impacted-tests")
-    click.secho("  git-mode: {}".format(git_mode), fg="blue", bold=True)
-    click.secho("  base-branch: {}".format(base_branch), fg="blue", bold=True)
-    click.secho("  root-dir: {}".format(root_dir), fg="blue", bold=True)
-    click.secho("  ns-module: {}".format(ns_module), fg="blue", bold=True)
-    click.secho("  tests-dir: {}".format(tests_dir), fg="blue", bold=True)
+    click.echo("impacted-tests", err=True)
+    click.secho("  git-mode: {}".format(git_mode), fg="blue", bold=True, err=True)
+    click.secho("  base-branch: {}".format(base_branch), fg="blue", bold=True, err=True)
+    click.secho("  root-dir: {}".format(root_dir), fg="blue", bold=True, err=True)
+    click.secho("  ns-module: {}".format(ns_module), fg="blue", bold=True, err=True)
+    click.secho("  tests-dir: {}".format(tests_dir), fg="blue", bold=True, err=True)
 
     configure_logging(verbose=verbose)
 
@@ -58,4 +64,8 @@ def impacted_tests_cli(git_mode, base_branch, root_dir, ns_module, tests_dir, ve
         tests_dir=tests_dir,
     )
 
-    click.secho("impacted tests: {}".format(impacted_tests), fg="blue", bold=True)
+    if impacted_tests:
+        for impacted_test in impacted_tests:
+            print(impacted_test)
+    else:
+        click.secho("No impacted tests found.", fg="red", bold=True, err=True)

--- a/pytest_impacted/cli.py
+++ b/pytest_impacted/cli.py
@@ -32,7 +32,7 @@ def configure_logging(verbose: bool) -> None:
     help="Root directory for project repository.",
 )
 @click.option(
-    "--ns-module",
+    "--module",
     required=True,
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
     help="Namespace (top-level) module for package we are testing.",
@@ -46,13 +46,13 @@ def configure_logging(verbose: bool) -> None:
     ),
 )
 @click.option("--verbose", is_flag=True, help="Verbose output.")
-def impacted_tests_cli(git_mode, base_branch, root_dir, ns_module, tests_dir, verbose):
+def impacted_tests_cli(git_mode, base_branch, root_dir, module, tests_dir, verbose):
     """CLI entrypoint for impacted-tests console script."""
     click.echo("impacted-tests", err=True)
-    click.secho("  git-mode: {}".format(git_mode), fg="blue", bold=True, err=True)
     click.secho("  base-branch: {}".format(base_branch), fg="blue", bold=True, err=True)
+    click.secho("  git-mode: {}".format(git_mode), fg="blue", bold=True, err=True)
+    click.secho("  module: {}".format(module), fg="blue", bold=True, err=True)
     click.secho("  root-dir: {}".format(root_dir), fg="blue", bold=True, err=True)
-    click.secho("  ns-module: {}".format(ns_module), fg="blue", bold=True, err=True)
     click.secho("  tests-dir: {}".format(tests_dir), fg="blue", bold=True, err=True)
 
     configure_logging(verbose=verbose)
@@ -61,7 +61,7 @@ def impacted_tests_cli(git_mode, base_branch, root_dir, ns_module, tests_dir, ve
         impacted_git_mode=git_mode,
         impacted_base_branch=base_branch,
         root_dir=root_dir,
-        ns_module=ns_module,
+        module=module,
         tests_dir=tests_dir,
     )
 

--- a/pytest_impacted/cli.py
+++ b/pytest_impacted/cli.py
@@ -61,7 +61,7 @@ def impacted_tests_cli(git_mode, base_branch, root_dir, module, tests_dir, verbo
         impacted_git_mode=git_mode,
         impacted_base_branch=base_branch,
         root_dir=root_dir,
-        module=module,
+        ns_module=module,
         tests_dir=tests_dir,
     )
 

--- a/pytest_impacted/cli.py
+++ b/pytest_impacted/cli.py
@@ -1,9 +1,9 @@
 """CLI entrypoints for pytest-impacted."""
 
 import logging
-import sys
 
 import click
+from rich.console import Console
 from rich.logging import RichHandler
 
 from pytest_impacted.api import get_impacted_tests
@@ -12,12 +12,13 @@ from pytest_impacted.git import GitMode
 
 def configure_logging(verbose: bool) -> None:
     """Configure logging for the CLIs."""
+    # Default to using stderr for logs as we want stdout for pipe-able output.
+    console = Console(stderr=True)
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
         format="%(funcName)-20s | %(message)s",
         datefmt="[%x]",
-        handlers=[RichHandler(rich_tracebacks=True, markup=True)],
-        stream=sys.stderr,
+        handlers=[RichHandler(console=console, markup=True, rich_tracebacks=True)],
     )
 
 

--- a/pytest_impacted/display.py
+++ b/pytest_impacted/display.py
@@ -12,7 +12,7 @@ def notify(message: str, session) -> None:
             bold=True,
         )
     else:
-        logging.info(f"\n{message}\n")
+        logging.info("\n%s\n", message)
 
 
 def warn(message: str, session) -> None:
@@ -24,4 +24,4 @@ def warn(message: str, session) -> None:
             bold=True,
         )
     else:
-        logging.warning(f"\nWARNING: {message}\n")
+        logging.warning("\nWARNING: %s\n", message)

--- a/pytest_impacted/git.py
+++ b/pytest_impacted/git.py
@@ -14,7 +14,8 @@ except ImportError:
     GIT_AVAILABLE = False
     warnings.warn(
         "GitPython package is not available. Git-related functionality will be disabled. "
-        "To enable git functionality, install GitPython and ensure git CLI is available."
+        "To enable git functionality, install GitPython and ensure git CLI is available.",
+        stacklevel=2,
     )
 
 
@@ -176,7 +177,8 @@ def find_impacted_files_in_repo(repo_dir: str | Path, git_mode: GitMode, base_br
     if not GIT_AVAILABLE:
         warnings.warn(
             "Git functionality is disabled because GitPython is not available. "
-            "To enable git functionality, install GitPython and ensure git CLI is available."
+            "To enable git functionality, install GitPython and ensure git CLI is available.",
+            stacklevel=2,
         )
         return None
 

--- a/pytest_impacted/graph.py
+++ b/pytest_impacted/graph.py
@@ -5,8 +5,8 @@ import types
 
 import networkx as nx
 
-from pytest_impacted.traversal import import_submodules
 from pytest_impacted.parsing import is_test_module, parse_module_imports
+from pytest_impacted.traversal import import_submodules
 
 
 def resolve_impacted_tests(impacted_modules, dep_tree: nx.DiGraph) -> list[str]:
@@ -15,11 +15,7 @@ def resolve_impacted_tests(impacted_modules, dep_tree: nx.DiGraph) -> list[str]:
     for module in impacted_modules:
         # Find all nodes that depend on the modified module by doing a DFS from the module
         # using the (inverted) directed graph of imports which is the dependency graph.
-        dependent_nodes = [
-            node
-            for node in nx.dfs_preorder_nodes(dep_tree, source=module)
-            if is_test_module(node)
-        ]
+        dependent_nodes = [node for node in nx.dfs_preorder_nodes(dep_tree, source=module) if is_test_module(node)]
 
         impacted_tests.extend(dependent_nodes)
 
@@ -30,9 +26,7 @@ def resolve_impacted_tests(impacted_modules, dep_tree: nx.DiGraph) -> list[str]:
     return impacted_tests
 
 
-def build_dep_tree(
-    package: str | types.ModuleType, tests_package: str | types.ModuleType | None = None
-) -> nx.DiGraph:
+def build_dep_tree(package: str | types.ModuleType, tests_package: str | types.ModuleType | None = None) -> nx.DiGraph:
     """Run the script for a given package name."""
     submodules = import_submodules(package)
 

--- a/pytest_impacted/parsing.py
+++ b/pytest_impacted/parsing.py
@@ -27,9 +27,7 @@ def parse_module_imports(module: types.ModuleType) -> list[str]:
         if module.__file__ and should_silently_ignore_oserror(module.__file__):
             return []
         else:
-            logging.error(
-                "Exception raised while trying to get source code for module %s", module
-            )
+            logging.error("Exception raised while trying to get source code for module %s", module)
             raise
 
     if not source:

--- a/pytest_impacted/plugin.py
+++ b/pytest_impacted/plugin.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from pytest import Config, Parser, UsageError
 
-from pytest_impacted.api import matches_impacted_tests, get_impacted_tests
+from pytest_impacted.api import get_impacted_tests, matches_impacted_tests
 from pytest_impacted.git import GitMode
 
 
@@ -73,7 +73,10 @@ def pytest_addoption(parser: Parser):
         action="store",
         default=None,
         dest="impacted_tests_dir",
-        help="Directory containing the unit-test files. If not specified, tests will only be found under namespace module directory.",
+        help=(
+            "Directory containing the unit-test files. If not specified, "
+            + "tests will only be found under namespace module directory."
+        ),
     )
     parser.addini(
         "impacted_tests_dir",
@@ -172,19 +175,11 @@ def validate_config(config: Config):
     if get_option("impacted"):
         if not get_option("impacted_module"):
             # If the impacted option is set, we need to check if there is a module specified.
-            raise UsageError(
-                "No module specified. Please specify a module using --impacted-module."
-            )
+            raise UsageError("No module specified. Please specify a module using --impacted-module.")
         if not get_option("impacted_git_mode"):
             # If the impacted option is set, we need to check if there is a git mode specified.
-            raise UsageError(
-                "No git mode specified. Please specify a git mode using --impacted-git-mode."
-            )
+            raise UsageError("No git mode specified. Please specify a git mode using --impacted-git-mode.")
 
-        if get_option("impacted_git_mode") == GitMode.BRANCH and not get_option(
-            "impacted_base_branch"
-        ):
+        if get_option("impacted_git_mode") == GitMode.BRANCH and not get_option("impacted_base_branch"):
             # If the git mode is branch, we need to check if there is a base branch specified.
-            raise UsageError(
-                "No base branch specified. Please specify a base branch using --impacted-base-branch."
-            )
+            raise UsageError("No base branch specified. Please specify a base branch using --impacted-base-branch.")

--- a/pytest_impacted/traversal.py
+++ b/pytest_impacted/traversal.py
@@ -78,9 +78,7 @@ def import_submodules(package: str | types.ModuleType) -> dict[str, types.Module
     return results
 
 
-def resolve_files_to_modules(
-    filenames: list[str], ns_module: str, tests_package: str | None = None
-):
+def resolve_files_to_modules(filenames: list[str], ns_module: str, tests_package: str | None = None):
     """Resolve file paths to their corresponding Python module objects."""
     # Get the path to the package
     path = Path(importlib.import_module(ns_module).__path__[0])
@@ -95,12 +93,7 @@ def resolve_files_to_modules(
         # Check if the file is a Python module
         if file.endswith(".py"):
             # TODO: Refactor this to use the path_to_package_name function ideally.
-            module_name = (
-                file.replace(str(path), "")
-                .replace("/", ".")
-                .replace(".py", "")
-                .lstrip(".")
-            )
+            module_name = file.replace(str(path), "").replace("/", ".").replace(".py", "").lstrip(".")
 
             if module_name in submodules:
                 resolved_modules.append(module_name)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,8 @@
 """Unit-tests for the api module."""
 
+import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pytest_impacted.api import get_impacted_tests, matches_impacted_tests
 from pytest_impacted.git import GitMode
@@ -61,3 +62,248 @@ def test_get_impacted_tests_no_impacted_files(mock_find_impacted_files):
     )
     assert result is None
     mock_find_impacted_files.assert_called_once_with(Path("."), git_mode=GitMode.UNSTAGED, base_branch="main")
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+@patch("pytest_impacted.api.build_dep_tree")
+@patch("pytest_impacted.api.resolve_impacted_tests")
+@patch("pytest_impacted.api.resolve_modules_to_files")
+@patch("pytest_impacted.api.path_to_package_name")
+def test_get_impacted_tests_success_with_tests_dir(
+    mock_path_to_package_name,
+    mock_resolve_modules_to_files,
+    mock_resolve_impacted_tests,
+    mock_build_dep_tree,
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests successful path with tests_dir."""
+    # Setup mocks
+    mock_find_impacted_files.return_value = ["file1.py", "file2.py"]
+    mock_resolve_files_to_modules.return_value = ["module1", "module2"]
+    mock_build_dep_tree.return_value = MagicMock()
+    mock_resolve_impacted_tests.return_value = ["test_module1", "test_module2"]
+    mock_resolve_modules_to_files.return_value = ["test_file1.py", "test_file2.py"]
+    mock_path_to_package_name.return_value = "tests"
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir="tests",
+    )
+
+    assert result == ["test_file1.py", "test_file2.py"]
+    mock_path_to_package_name.assert_called_once_with("tests")
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+def test_get_impacted_tests_no_impacted_modules(
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests when no impacted modules are found."""
+    mock_find_impacted_files.return_value = ["file1.py", "file2.py"]
+    mock_resolve_files_to_modules.return_value = []
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+    )
+
+    assert result is None
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+@patch("pytest_impacted.api.build_dep_tree")
+@patch("pytest_impacted.api.resolve_impacted_tests")
+def test_get_impacted_tests_no_impacted_test_modules(
+    mock_resolve_impacted_tests,
+    mock_build_dep_tree,
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests when no impacted test modules are found."""
+    mock_find_impacted_files.return_value = ["file1.py"]
+    mock_resolve_files_to_modules.return_value = ["module1"]
+    mock_build_dep_tree.return_value = MagicMock()
+    mock_resolve_impacted_tests.return_value = []
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+    )
+
+    assert result is None
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+@patch("pytest_impacted.api.build_dep_tree")
+@patch("pytest_impacted.api.resolve_impacted_tests")
+@patch("pytest_impacted.api.resolve_modules_to_files")
+def test_get_impacted_tests_no_impacted_test_files(
+    mock_resolve_modules_to_files,
+    mock_resolve_impacted_tests,
+    mock_build_dep_tree,
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests when no impacted test files are found."""
+    mock_find_impacted_files.return_value = ["file1.py"]
+    mock_resolve_files_to_modules.return_value = ["module1"]
+    mock_build_dep_tree.return_value = MagicMock()
+    mock_resolve_impacted_tests.return_value = ["test_module1"]
+    mock_resolve_modules_to_files.return_value = []
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+    )
+
+    assert result is None
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+@patch("pytest_impacted.api.build_dep_tree")
+@patch("pytest_impacted.api.resolve_impacted_tests")
+@patch("pytest_impacted.api.resolve_modules_to_files")
+def test_get_impacted_tests_success_without_tests_dir(
+    mock_resolve_modules_to_files,
+    mock_resolve_impacted_tests,
+    mock_build_dep_tree,
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests successful path without tests_dir."""
+    mock_find_impacted_files.return_value = ["file1.py"]
+    mock_resolve_files_to_modules.return_value = ["module1"]
+    mock_build_dep_tree.return_value = MagicMock()
+    mock_resolve_impacted_tests.return_value = ["test_module1"]
+    mock_resolve_modules_to_files.return_value = ["test_file1.py"]
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir=None,
+    )
+
+    assert result == ["test_file1.py"]
+    mock_resolve_files_to_modules.assert_called_once_with(["file1.py"], ns_module="project_ns", tests_package=None)
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.path_to_package_name")
+@patch("pytest_impacted.api.logging.debug")
+def test_get_impacted_tests_with_tests_dir_logging_debug(
+    mock_logging_debug,
+    mock_path_to_package_name,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests logs debug message when adding tests_dir parent to sys.path."""
+    mock_find_impacted_files.return_value = []
+    mock_path_to_package_name.return_value = "tests"
+
+    tests_dir = "/some/path/tests"
+    expected_parent = str(Path(tests_dir).resolve().parent)
+
+    # Ensure the parent path is not already in sys.path
+    if expected_parent in sys.path:
+        sys.path.remove(expected_parent)
+
+    get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir=tests_dir,
+    )
+
+    # Check that debug logging was called
+    mock_logging_debug.assert_called_once_with(
+        "Adding tests_dir parent directory to sys.path: %s", Path(expected_parent)
+    )
+
+    # Clean up
+    if expected_parent in sys.path:
+        sys.path.remove(expected_parent)
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.path_to_package_name")
+def test_get_impacted_tests_with_tests_dir_sys_path_modification(
+    mock_path_to_package_name,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests modifies sys.path when tests_dir is provided."""
+    mock_find_impacted_files.return_value = []
+    mock_path_to_package_name.return_value = "tests"
+
+    tests_dir = "/some/path/tests"
+    expected_parent = str(Path(tests_dir).resolve().parent)
+
+    # Ensure the parent path is not already in sys.path
+    if expected_parent in sys.path:
+        sys.path.remove(expected_parent)
+
+    original_path_length = len(sys.path)
+
+    get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir=tests_dir,
+    )
+
+    # Check that sys.path was modified
+    assert len(sys.path) == original_path_length + 1
+    assert sys.path[0] == expected_parent
+
+    # Clean up
+    sys.path.remove(expected_parent)
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.path_to_package_name")
+def test_get_impacted_tests_with_tests_dir_sys_path_already_present(
+    mock_path_to_package_name,
+    mock_find_impacted_files,
+):
+    """Test get_impacted_tests doesn't duplicate sys.path when tests_dir parent is already present."""
+    mock_find_impacted_files.return_value = []
+    mock_path_to_package_name.return_value = "tests"
+
+    tests_dir = "/some/path/tests"
+    expected_parent = str(Path(tests_dir).resolve().parent)
+
+    # Add the parent path to sys.path first
+    sys.path.insert(0, expected_parent)
+    original_path_length = len(sys.path)
+
+    get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir=tests_dir,
+    )
+
+    # Check that sys.path wasn't modified further
+    assert len(sys.path) == original_path_length
+
+    # Clean up
+    sys.path.remove(expected_parent)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from pytest_impacted.api import matches_impacted_tests, get_impacted_tests
+from pytest_impacted.api import get_impacted_tests, matches_impacted_tests
 from pytest_impacted.git import GitMode
 
 
@@ -39,9 +39,7 @@ def test_matches_impacted_tests_exact_match():
 
 def test_matches_impacted_tests_substring_not_suffix():
     item_path = "test_example.py"  # item_path is just 'test_example.py'
-    impacted_tests = [
-        "project/module/tests/test_example.pyc"
-    ]  # .pyc instead of .py, so not a suffix
+    impacted_tests = ["project/module/tests/test_example.pyc"]  # .pyc instead of .py, so not a suffix
     assert not matches_impacted_tests(item_path, impacted_tests=impacted_tests)
 
 
@@ -62,6 +60,4 @@ def test_get_impacted_tests_no_impacted_files(mock_find_impacted_files):
         tests_dir="tests",
     )
     assert result is None
-    mock_find_impacted_files.assert_called_once_with(
-        Path("."), git_mode=GitMode.UNSTAGED, base_branch="main"
-    )
+    mock_find_impacted_files.assert_called_once_with(Path("."), git_mode=GitMode.UNSTAGED, base_branch="main")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,7 +80,7 @@ class TestImpactedTestsCLI:
                 impacted_git_mode=GitMode.UNSTAGED,
                 impacted_base_branch="main",
                 root_dir=".",
-                module="test_ns",
+                ns_module="test_ns",
                 tests_dir=None,
             )
 
@@ -120,7 +120,7 @@ class TestImpactedTestsCLI:
                 impacted_git_mode=GitMode.BRANCH,
                 impacted_base_branch="develop",
                 root_dir=".",
-                module="test_ns",
+                ns_module="test_ns",
                 tests_dir="tests",
             )
 
@@ -266,7 +266,7 @@ class TestImpactedTestsCLI:
                 impacted_git_mode=GitMode.UNSTAGED,  # default
                 impacted_base_branch="main",  # default
                 root_dir=".",  # default
-                module="test_ns",
+                ns_module="test_ns",
                 tests_dir=None,  # default
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ class TestImpactedTestsCLI:
                     "main",
                     "--root-dir",
                     ".",
-                    "--ns-module",
+                    "--module",
                     "test_ns",
                     "--verbose",
                 ],
@@ -80,7 +80,7 @@ class TestImpactedTestsCLI:
                 impacted_git_mode=GitMode.UNSTAGED,
                 impacted_base_branch="main",
                 root_dir=".",
-                ns_module="test_ns",
+                module="test_ns",
                 tests_dir=None,
             )
 
@@ -108,7 +108,7 @@ class TestImpactedTestsCLI:
                     "develop",
                     "--root-dir",
                     ".",
-                    "--ns-module",
+                    "--module",
                     "test_ns",
                     "--tests-dir",
                     "tests",
@@ -120,7 +120,7 @@ class TestImpactedTestsCLI:
                 impacted_git_mode=GitMode.BRANCH,
                 impacted_base_branch="develop",
                 root_dir=".",
-                ns_module="test_ns",
+                module="test_ns",
                 tests_dir="tests",
             )
 
@@ -135,7 +135,7 @@ class TestImpactedTestsCLI:
 
             result = self.runner.invoke(
                 impacted_tests_cli,
-                ["--git-mode", "unstaged", "--base-branch", "main", "--root-dir", ".", "--ns-module", "test_ns"],
+                ["--git-mode", "unstaged", "--base-branch", "main", "--root-dir", ".", "--module", "test_ns"],
             )
 
             assert result.exit_code == 0
@@ -152,7 +152,7 @@ class TestImpactedTestsCLI:
 
             result = self.runner.invoke(
                 impacted_tests_cli,
-                ["--git-mode", "unstaged", "--base-branch", "main", "--root-dir", ".", "--ns-module", "test_ns"],
+                ["--git-mode", "unstaged", "--base-branch", "main", "--root-dir", ".", "--module", "test_ns"],
             )
 
             assert result.exit_code == 0
@@ -169,7 +169,7 @@ class TestImpactedTestsCLI:
                 "main",
                 "--root-dir",
                 ".",
-                # Missing --ns-module
+                # Missing --module
             ],
         )
 
@@ -183,7 +183,7 @@ class TestImpactedTestsCLI:
 
             result = self.runner.invoke(
                 impacted_tests_cli,
-                ["--git-mode", "invalid_mode", "--base-branch", "main", "--root-dir", ".", "--ns-module", "test_ns"],
+                ["--git-mode", "invalid_mode", "--base-branch", "main", "--root-dir", ".", "--module", "test_ns"],
             )
 
             assert result.exit_code != 0
@@ -201,14 +201,14 @@ class TestImpactedTestsCLI:
                 "main",
                 "--root-dir",
                 "/nonexistent/path",
-                "--ns-module",
+                "--module",
                 "test_ns",
             ],
         )
 
         assert result.exit_code != 0
 
-    def test_cli_nonexistent_ns_module(self):
+    def test_cli_nonexistent_module(self):
         """Test CLI fails with non-existent namespace module."""
         result = self.runner.invoke(
             impacted_tests_cli,
@@ -219,7 +219,7 @@ class TestImpactedTestsCLI:
                 "main",
                 "--root-dir",
                 ".",
-                "--ns-module",
+                "--module",
                 "/nonexistent/module",
             ],
         )
@@ -240,7 +240,7 @@ class TestImpactedTestsCLI:
                     "main",
                     "--root-dir",
                     ".",
-                    "--ns-module",
+                    "--module",
                     "test_ns",
                     "--tests-dir",
                     "/nonexistent/tests",
@@ -258,7 +258,7 @@ class TestImpactedTestsCLI:
         with self.runner.isolated_filesystem():
             Path("test_ns").mkdir()
 
-            result = self.runner.invoke(impacted_tests_cli, ["--ns-module", "test_ns"])
+            result = self.runner.invoke(impacted_tests_cli, ["--module", "test_ns"])
 
             assert result.exit_code == 0
             mock_configure_logging.assert_called_once_with(verbose=False)
@@ -266,7 +266,7 @@ class TestImpactedTestsCLI:
                 impacted_git_mode=GitMode.UNSTAGED,  # default
                 impacted_base_branch="main",  # default
                 root_dir=".",  # default
-                ns_module="test_ns",
+                module="test_ns",
                 tests_dir=None,  # default
             )
 
@@ -289,7 +289,7 @@ class TestImpactedTestsCLI:
                     "develop",
                     "--root-dir",
                     ".",
-                    "--ns-module",
+                    "--module",
                     "test_ns",
                     "--tests-dir",
                     "tests",
@@ -301,4 +301,4 @@ class TestImpactedTestsCLI:
             assert "impacted-tests" in result.output
             assert "git-mode: branch" in result.output
             assert "base-branch: develop" in result.output
-            assert "ns-module: test_ns" in result.output
+            assert "module: test_ns" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,304 @@
+"""Unit tests for the CLI module."""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from pytest_impacted.cli import configure_logging, impacted_tests_cli
+from pytest_impacted.git import GitMode
+
+
+class TestConfigureLogging:
+    """Tests for the configure_logging function."""
+
+    def test_configure_logging_verbose_true(self):
+        """Test that verbose=True sets DEBUG level."""
+        with patch("logging.basicConfig") as mock_basic_config:
+            configure_logging(verbose=True)
+
+            mock_basic_config.assert_called_once()
+            call_args = mock_basic_config.call_args
+            assert call_args[1]["level"] == logging.DEBUG
+
+    def test_configure_logging_verbose_false(self):
+        """Test that verbose=False sets INFO level."""
+        with patch("logging.basicConfig") as mock_basic_config:
+            configure_logging(verbose=False)
+
+            mock_basic_config.assert_called_once()
+            call_args = mock_basic_config.call_args
+            assert call_args[1]["level"] == logging.INFO
+
+    def test_configure_logging_format(self):
+        """Test that logging is configured with the expected format."""
+        with patch("logging.basicConfig") as mock_basic_config:
+            configure_logging(verbose=False)
+
+            mock_basic_config.assert_called_once()
+            call_args = mock_basic_config.call_args
+            assert call_args[1]["format"] == "%(funcName)-20s | %(message)s"
+            assert call_args[1]["datefmt"] == "[%x]"
+
+
+class TestImpactedTestsCLI:
+    """Tests for the impacted_tests_cli Click command."""
+
+    def setup_method(self):
+        """Set up test environment."""
+        self.runner = CliRunner()
+
+    @patch("pytest_impacted.cli.get_impacted_tests")
+    @patch("pytest_impacted.cli.configure_logging")
+    def test_cli_with_all_required_args(self, mock_configure_logging, mock_get_impacted_tests):
+        """Test CLI with all required arguments."""
+        mock_get_impacted_tests.return_value = ["tests/test_example.py", "tests/test_other.py"]
+
+        with self.runner.isolated_filesystem():
+            # Create test directories
+            Path("test_ns").mkdir()
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                [
+                    "--git-mode",
+                    "unstaged",
+                    "--base-branch",
+                    "main",
+                    "--root-dir",
+                    ".",
+                    "--ns-module",
+                    "test_ns",
+                    "--verbose",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_configure_logging.assert_called_once_with(verbose=True)
+            mock_get_impacted_tests.assert_called_once_with(
+                impacted_git_mode=GitMode.UNSTAGED,
+                impacted_base_branch="main",
+                root_dir=".",
+                ns_module="test_ns",
+                tests_dir=None,
+            )
+
+            # Check that the impacted tests are printed to stdout
+            assert "tests/test_example.py" in result.output
+            assert "tests/test_other.py" in result.output
+
+    @patch("pytest_impacted.cli.get_impacted_tests")
+    @patch("pytest_impacted.cli.configure_logging")
+    def test_cli_with_tests_dir(self, mock_configure_logging, mock_get_impacted_tests):
+        """Test CLI with tests-dir specified."""
+        mock_get_impacted_tests.return_value = ["tests/test_example.py"]
+
+        with self.runner.isolated_filesystem():
+            # Create test directories
+            Path("test_ns").mkdir()
+            Path("tests").mkdir()
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                [
+                    "--git-mode",
+                    "branch",
+                    "--base-branch",
+                    "develop",
+                    "--root-dir",
+                    ".",
+                    "--ns-module",
+                    "test_ns",
+                    "--tests-dir",
+                    "tests",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_get_impacted_tests.assert_called_once_with(
+                impacted_git_mode=GitMode.BRANCH,
+                impacted_base_branch="develop",
+                root_dir=".",
+                ns_module="test_ns",
+                tests_dir="tests",
+            )
+
+    @patch("pytest_impacted.cli.get_impacted_tests")
+    @patch("pytest_impacted.cli.configure_logging")
+    def test_cli_no_impacted_tests(self, mock_configure_logging, mock_get_impacted_tests):
+        """Test CLI when no impacted tests are found."""
+        mock_get_impacted_tests.return_value = None
+
+        with self.runner.isolated_filesystem():
+            Path("test_ns").mkdir()
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                ["--git-mode", "unstaged", "--base-branch", "main", "--root-dir", ".", "--ns-module", "test_ns"],
+            )
+
+            assert result.exit_code == 0
+            assert "No impacted tests found." in result.output
+
+    @patch("pytest_impacted.cli.get_impacted_tests")
+    @patch("pytest_impacted.cli.configure_logging")
+    def test_cli_empty_impacted_tests_list(self, mock_configure_logging, mock_get_impacted_tests):
+        """Test CLI when empty list of impacted tests is returned."""
+        mock_get_impacted_tests.return_value = []
+
+        with self.runner.isolated_filesystem():
+            Path("test_ns").mkdir()
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                ["--git-mode", "unstaged", "--base-branch", "main", "--root-dir", ".", "--ns-module", "test_ns"],
+            )
+
+            assert result.exit_code == 0
+            assert "No impacted tests found." in result.output
+
+    def test_cli_missing_required_arg(self):
+        """Test CLI fails when required argument is missing."""
+        result = self.runner.invoke(
+            impacted_tests_cli,
+            [
+                "--git-mode",
+                "unstaged",
+                "--base-branch",
+                "main",
+                "--root-dir",
+                ".",
+                # Missing --ns-module
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Missing option" in result.output
+
+    def test_cli_invalid_git_mode(self):
+        """Test CLI fails with invalid git mode."""
+        with self.runner.isolated_filesystem():
+            Path("test_ns").mkdir()
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                ["--git-mode", "invalid_mode", "--base-branch", "main", "--root-dir", ".", "--ns-module", "test_ns"],
+            )
+
+            assert result.exit_code != 0
+            # The invalid git mode should cause an error during execution
+            assert result.exception is not None
+
+    def test_cli_nonexistent_root_dir(self):
+        """Test CLI fails with non-existent root directory."""
+        result = self.runner.invoke(
+            impacted_tests_cli,
+            [
+                "--git-mode",
+                "unstaged",
+                "--base-branch",
+                "main",
+                "--root-dir",
+                "/nonexistent/path",
+                "--ns-module",
+                "test_ns",
+            ],
+        )
+
+        assert result.exit_code != 0
+
+    def test_cli_nonexistent_ns_module(self):
+        """Test CLI fails with non-existent namespace module."""
+        result = self.runner.invoke(
+            impacted_tests_cli,
+            [
+                "--git-mode",
+                "unstaged",
+                "--base-branch",
+                "main",
+                "--root-dir",
+                ".",
+                "--ns-module",
+                "/nonexistent/module",
+            ],
+        )
+
+        assert result.exit_code != 0
+
+    def test_cli_nonexistent_tests_dir(self):
+        """Test CLI fails with non-existent tests directory."""
+        with self.runner.isolated_filesystem():
+            Path("test_ns").mkdir()
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                [
+                    "--git-mode",
+                    "unstaged",
+                    "--base-branch",
+                    "main",
+                    "--root-dir",
+                    ".",
+                    "--ns-module",
+                    "test_ns",
+                    "--tests-dir",
+                    "/nonexistent/tests",
+                ],
+            )
+
+            assert result.exit_code != 0
+
+    @patch("pytest_impacted.cli.get_impacted_tests")
+    @patch("pytest_impacted.cli.configure_logging")
+    def test_cli_defaults(self, mock_configure_logging, mock_get_impacted_tests):
+        """Test CLI with default values."""
+        mock_get_impacted_tests.return_value = ["tests/test_example.py"]
+
+        with self.runner.isolated_filesystem():
+            Path("test_ns").mkdir()
+
+            result = self.runner.invoke(impacted_tests_cli, ["--ns-module", "test_ns"])
+
+            assert result.exit_code == 0
+            mock_configure_logging.assert_called_once_with(verbose=False)
+            mock_get_impacted_tests.assert_called_once_with(
+                impacted_git_mode=GitMode.UNSTAGED,  # default
+                impacted_base_branch="main",  # default
+                root_dir=".",  # default
+                ns_module="test_ns",
+                tests_dir=None,  # default
+            )
+
+    @patch("pytest_impacted.cli.get_impacted_tests")
+    @patch("pytest_impacted.cli.configure_logging")
+    def test_cli_stderr_output(self, mock_configure_logging, mock_get_impacted_tests):
+        """Test that CLI outputs configuration info to stderr."""
+        mock_get_impacted_tests.return_value = ["tests/test_example.py"]
+
+        with self.runner.isolated_filesystem():
+            Path("test_ns").mkdir()
+            Path("tests").mkdir()  # Create the tests directory
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                [
+                    "--git-mode",
+                    "branch",
+                    "--base-branch",
+                    "develop",
+                    "--root-dir",
+                    ".",
+                    "--ns-module",
+                    "test_ns",
+                    "--tests-dir",
+                    "tests",
+                ],
+            )
+
+            # Check that configuration is shown in output
+            assert result.exit_code == 0
+            assert "impacted-tests" in result.output
+            assert "git-mode: branch" in result.output
+            assert "base-branch: develop" in result.output
+            assert "ns-module: test_ns" in result.output

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,6 +1,7 @@
 """Unit tests for the display module."""
 
 from unittest.mock import MagicMock
+
 from pytest_impacted import display
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,6 +1,7 @@
 """Unit tests for the display module."""
 
-from unittest.mock import MagicMock
+import logging
+from unittest.mock import MagicMock, patch
 
 from pytest_impacted import display
 
@@ -34,3 +35,17 @@ def test_warn():
     assert "WARNING: Danger!" in args[0]
     assert kwargs.get("yellow") is True
     assert kwargs.get("bold") is True
+
+
+def test_notify_without_session():
+    """Test notify function when session is None."""
+    with patch.object(logging, "info") as mock_info:
+        display.notify("Hello, world!", None)
+        mock_info.assert_called_once_with("\nHello, world!\n")
+
+
+def test_warn_without_session():
+    """Test warn function when session is None."""
+    with patch.object(logging, "warning") as mock_warning:
+        display.warn("Danger!", None)
+        mock_warning.assert_called_once_with("\nWARNING: Danger!\n")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -41,11 +41,11 @@ def test_notify_without_session():
     """Test notify function when session is None."""
     with patch.object(logging, "info") as mock_info:
         display.notify("Hello, world!", None)
-        mock_info.assert_called_once_with("\nHello, world!\n")
+        mock_info.assert_called_once_with("\n%s\n", "Hello, world!")
 
 
 def test_warn_without_session():
     """Test warn function when session is None."""
     with patch.object(logging, "warning") as mock_warning:
         display.warn("Danger!", None)
-        mock_warning.assert_called_once_with("\nWARNING: Danger!\n")
+        mock_warning.assert_called_once_with("\nWARNING: %s\n", "Danger!")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -135,20 +135,21 @@ def test_without_nones():
     assert git.without_nones([]) == []
 
 
-def test_git_status_from_git_diff_name_status():
+@pytest.mark.parametrize(
+    "input_status,expected_status",
+    [
+        ("A", git.GitStatus.ADDED),
+        ("M", git.GitStatus.MODIFIED),
+        ("D", git.GitStatus.DELETED),
+        ("R100", git.GitStatus.RENAMED),
+        ("R75", git.GitStatus.RENAMED),
+        ("C100", git.GitStatus.COPIED),
+        ("C85", git.GitStatus.COPIED),
+    ],
+)
+def test_git_status_from_git_diff_name_status(input_status, expected_status):
     """Test GitStatus.from_git_diff_name_status with various status codes."""
-    # Test basic status codes
-    assert git.GitStatus.from_git_diff_name_status("A") == git.GitStatus.ADDED
-    assert git.GitStatus.from_git_diff_name_status("M") == git.GitStatus.MODIFIED
-    assert git.GitStatus.from_git_diff_name_status("D") == git.GitStatus.DELETED
-
-    # Test rename with similarity score
-    assert git.GitStatus.from_git_diff_name_status("R100") == git.GitStatus.RENAMED
-    assert git.GitStatus.from_git_diff_name_status("R75") == git.GitStatus.RENAMED
-
-    # Test copy with similarity score
-    assert git.GitStatus.from_git_diff_name_status("C100") == git.GitStatus.COPIED
-    assert git.GitStatus.from_git_diff_name_status("C85") == git.GitStatus.COPIED
+    assert git.GitStatus.from_git_diff_name_status(input_status) == expected_status
 
 
 def test_changeset_from_git_diff_name_status_with_scores():
@@ -180,3 +181,363 @@ D\tdeleted.py"""
     # Verify deleted file
     assert changes[3].status == git.GitStatus.DELETED
     assert changes[3].name == "deleted.py"
+
+
+def test_deleted_files_from_diff():
+    """Test deleted_files_from_diff function."""
+    changes = [
+        git.Change(a_path="deleted1.py", status=git.GitStatus.DELETED),
+        git.Change(a_path="modified.py", status=git.GitStatus.MODIFIED),
+        git.Change(a_path="deleted2.py", status=git.GitStatus.DELETED),
+        git.Change(a_path="added.py", status=git.GitStatus.ADDED),
+    ]
+    change_set = git.ChangeSet(changes)
+
+    deleted_files = git.deleted_files_from_diff(change_set)
+    assert set(deleted_files) == {"deleted1.py", "deleted2.py"}
+
+
+def test_change_class():
+    """Test the Change class."""
+    # Test with all parameters
+    change = git.Change(a_path="file.py", b_path="new_file.py", status=git.GitStatus.RENAMED)
+    assert change.a_path == "file.py"
+    assert change.b_path == "new_file.py"
+    assert change.status == git.GitStatus.RENAMED
+    assert change.name == "file.py"
+
+    # Test with only b_path (new file)
+    change_new = git.Change(a_path=None, b_path="new_file.py", status=git.GitStatus.ADDED)
+    assert change_new.name == "new_file.py"
+
+    # Test string representation
+    change_str = git.Change(a_path="file.py", status=git.GitStatus.MODIFIED)
+    assert str(change_str) == "M\tfile.py"
+
+
+def test_change_from_git_diff_name_status_simple():
+    """Test Change.from_git_diff_name_status with simple status codes."""
+    # Test modified file
+    change = git.Change.from_git_diff_name_status(name="file.py", status="M")
+    assert change.a_path == "file.py"
+    assert change.b_path is None
+    assert change.status == git.GitStatus.MODIFIED
+
+    # Test added file
+    change = git.Change.from_git_diff_name_status(name="new_file.py", status="A")
+    assert change.a_path == "new_file.py"
+    assert change.status == git.GitStatus.ADDED
+
+    # Test with None status
+    change = git.Change.from_git_diff_name_status(name="file.py", status=None)
+    assert change.a_path == "file.py"
+    assert change.status is None
+
+
+def test_change_from_git_diff_name_status_rename_copy():
+    """Test Change.from_git_diff_name_status with rename and copy operations."""
+    # Test rename with tab-separated paths
+    change = git.Change.from_git_diff_name_status(name="old_file.py\tnew_file.py", status="R100")
+    assert change.a_path == "old_file.py"
+    assert change.b_path == "new_file.py"
+    assert change.status == git.GitStatus.RENAMED
+
+    # Test copy with tab-separated paths
+    change = git.Change.from_git_diff_name_status(name="original.py\tcopy.py", status="C85")
+    assert change.a_path == "original.py"
+    assert change.b_path == "copy.py"
+    assert change.status == git.GitStatus.COPIED
+
+    # Test rename without tab (edge case)
+    change = git.Change.from_git_diff_name_status(name="file.py", status="R100")
+    assert change.a_path == "file.py"
+    assert change.b_path is None
+    assert change.status == git.GitStatus.RENAMED
+
+
+def test_changeset_class():
+    """Test the ChangeSet class."""
+    changes = [
+        git.Change(a_path="file1.py", status=git.GitStatus.MODIFIED),
+        git.Change(a_path="file2.py", status=git.GitStatus.ADDED),
+    ]
+    change_set = git.ChangeSet(changes)
+
+    assert len(change_set.changes) == 2
+    assert "M\tfile1.py" in str(change_set)
+    assert "A\tfile2.py" in str(change_set)
+
+
+def test_changeset_from_diff_objs():
+    """Test ChangeSet.from_diff_objs method."""
+    # Create mock diff objects
+    diff1 = MagicMock(a_path="file1.py", b_path=None, change_type="M")
+    diff2 = MagicMock(a_path=None, b_path="file2.py", change_type="A")
+    diff3 = MagicMock(a_path="old.py", b_path="new.py", change_type="R")
+
+    diffs = [diff1, diff2, diff3]
+    change_set = git.ChangeSet.from_diff_objs(diffs)
+
+    assert len(change_set.changes) == 3
+    assert change_set.changes[0].name == "file1.py"
+    assert change_set.changes[1].name == "file2.py"
+    assert change_set.changes[2].name == "old.py"
+
+
+def test_changeset_from_git_diff_name_status_output():
+    """Test ChangeSet.from_git_diff_name_status_output method."""
+    diff_output = """M\tmodified.py
+A\tadded.py
+D\tdeleted.py"""
+
+    change_set = git.ChangeSet.from_git_diff_name_status_output(diff_output)
+
+    assert len(change_set.changes) == 3
+    assert change_set.changes[0].status == git.GitStatus.MODIFIED
+    assert change_set.changes[1].status == git.GitStatus.ADDED
+    assert change_set.changes[2].status == git.GitStatus.DELETED
+
+
+def test_changeset_from_git_diff_name_status_output_empty():
+    """Test ChangeSet.from_git_diff_name_status_output with empty input."""
+    change_set = git.ChangeSet.from_git_diff_name_status_output("")
+    assert len(change_set.changes) == 0
+
+
+@patch("pytest_impacted.git.Repo")
+def test_impacted_files_for_unstaged_mode_clean_repo(mock_repo):
+    """Test impacted_files_for_unstaged_mode with clean repo."""
+    repo = DummyRepo(dirty=False)
+    result = git.impacted_files_for_unstaged_mode(repo)
+    assert result is None
+
+
+@patch("pytest_impacted.git.Repo")
+def test_impacted_files_for_unstaged_mode_with_deleted_files(mock_repo):
+    """Test impacted_files_for_unstaged_mode with deleted files."""
+    diff1 = MagicMock(a_path="file1.py", b_path=None, change_type="M")
+    diff2 = MagicMock(a_path="deleted.py", b_path=None, change_type="D")
+    diff_result = [diff1, diff2]
+
+    repo = DummyRepo(dirty=True, diff_result=diff_result)
+    result = git.impacted_files_for_unstaged_mode(repo)
+
+    # Should only include modified and added files, not deleted
+    assert result == ["file1.py"]
+
+
+@patch("pytest_impacted.git.Repo")
+def test_impacted_files_for_branch_mode_with_deleted_files(mock_repo):
+    """Test impacted_files_for_branch_mode with deleted files."""
+    diff_output = """M\tmodified.py
+D\tdeleted.py
+A\tadded.py"""
+
+    repo = DummyRepo(diff_branch_result=diff_output)
+    result = git.impacted_files_for_branch_mode(repo, "main")
+
+    # Should only include modified and added files, not deleted
+    assert set(result) == {"modified.py", "added.py"}
+
+
+def test_git_status_enum_values():
+    """Test all GitStatus enum values."""
+    assert git.GitStatus.ADDED.value == "A"
+    assert git.GitStatus.COPIED.value == "C"
+    assert git.GitStatus.DELETED.value == "D"
+    assert git.GitStatus.MODIFIED.value == "M"
+    assert git.GitStatus.RENAMED.value == "R"
+    assert git.GitStatus.TYPE_CHANGE.value == "T"
+    assert git.GitStatus.UNMERGED.value == "U"
+    assert git.GitStatus.UNKNOWN.value == "X"
+    assert git.GitStatus.PAIRING_BROKEN.value == "B"
+
+
+def test_git_mode_enum_values():
+    """Test GitMode enum values."""
+    assert git.GitMode.UNSTAGED.value == "unstaged"
+    assert git.GitMode.BRANCH.value == "branch"
+
+
+@patch("pytest_impacted.git.GIT_AVAILABLE", True)
+@patch("pytest_impacted.git.warnings.warn")
+def test_git_available_warning_not_called(mock_warn):
+    """Test that warning is not called when git is available."""
+    # Import should not trigger warning when GIT_AVAILABLE is True
+    mock_warn.assert_not_called()
+
+
+def test_git_unavailable_warning():
+    """Test that warning is triggered when GitPython is not available."""
+    with patch("pytest_impacted.git.GIT_AVAILABLE", False):
+        with pytest.warns(UserWarning, match="Git functionality is disabled"):
+            git.find_impacted_files_in_repo(".", git.GitMode.UNSTAGED, None)
+
+
+def test_git_status_from_git_diff_name_status_edge_cases():
+    """Test GitStatus.from_git_diff_name_status with edge cases."""
+    # Test copy with non-digit after C - this should raise ValueError as "CX" is not a valid status
+    with pytest.raises(ValueError):
+        git.GitStatus.from_git_diff_name_status("CX")
+
+    # Test rename with non-digit after R - this should raise ValueError as "RX" is not a valid status
+    with pytest.raises(ValueError):
+        git.GitStatus.from_git_diff_name_status("RX")
+
+    # Test other valid status codes
+    assert git.GitStatus.from_git_diff_name_status("T") == git.GitStatus.TYPE_CHANGE
+    assert git.GitStatus.from_git_diff_name_status("U") == git.GitStatus.UNMERGED
+    assert git.GitStatus.from_git_diff_name_status("X") == git.GitStatus.UNKNOWN
+    assert git.GitStatus.from_git_diff_name_status("B") == git.GitStatus.PAIRING_BROKEN
+
+
+def test_changeset_from_git_diff_name_status_output_single_column():
+    """Test ChangeSet.from_git_diff_name_status_output with single column input."""
+    diff_output = "M"
+    # This should raise a ValueError due to unpacking error when split doesn't return 2 elements
+    with pytest.raises(ValueError):
+        git.ChangeSet.from_git_diff_name_status_output(diff_output)
+
+
+def test_changeset_from_git_diff_name_status_output_malformed():
+    """Test ChangeSet.from_git_diff_name_status_output with malformed input."""
+    # This tests the edge case where split doesn't return exactly 2 elements
+    diff_output = "M\tfile1.py\textra_data"
+    change_set = git.ChangeSet.from_git_diff_name_status_output(diff_output)
+
+    assert len(change_set.changes) == 1
+    # The split with maxsplit=1 should handle this correctly
+    assert change_set.changes[0].status == git.GitStatus.MODIFIED
+    assert change_set.changes[0].name == "file1.py\textra_data"
+
+
+@patch("pytest_impacted.git.Repo")
+def test_find_impacted_files_in_repo_with_path_object(mock_repo):
+    """Test find_impacted_files_in_repo with Path object instead of string."""
+    from pathlib import Path
+
+    diff1 = MagicMock(a_path="file1.py", b_path=None, change_type="M")
+    diff_result = [diff1]
+    mock_repo.return_value = DummyRepo(dirty=True, diff_result=diff_result)
+
+    result = git.find_impacted_files_in_repo(Path("."), git.GitMode.UNSTAGED, None)
+    assert result == ["file1.py"]
+    # Verify that Repo was called with a Path object
+    mock_repo.assert_called_once_with(path=Path("."))
+
+
+def test_change_name_property_with_both_paths():
+    """Test Change.name property when both a_path and b_path are present."""
+    change = git.Change(a_path="old_file.py", b_path="new_file.py", status=git.GitStatus.RENAMED)
+    # When both paths are present, name should return a_path
+    assert change.name == "old_file.py"
+
+
+def test_change_name_property_with_none_paths():
+    """Test Change.name property when both paths are None."""
+    change = git.Change(a_path=None, b_path=None, status=git.GitStatus.UNKNOWN)
+    assert change.name is None
+
+
+def test_git_module_docstring():
+    """Test that the git module has the expected docstring."""
+    assert git.__doc__ == "Git related functions."
+
+
+def test_change_str_with_none_status():
+    """Test Change.__str__ method with None status."""
+    change = git.Change(a_path="file.py", status=None)
+    assert str(change) == "None\tfile.py"
+
+
+def test_changeset_str_empty():
+    """Test ChangeSet.__str__ method with empty changes."""
+    change_set = git.ChangeSet([])
+    assert str(change_set) == ""
+
+
+def test_changeset_str_multiple_changes():
+    """Test ChangeSet.__str__ method with multiple changes."""
+    changes = [
+        git.Change(a_path="file1.py", status=git.GitStatus.MODIFIED),
+        git.Change(a_path="file2.py", status=git.GitStatus.ADDED),
+    ]
+    change_set = git.ChangeSet(changes)
+    expected = "M\tfile1.py\nA\tfile2.py"
+    assert str(change_set) == expected
+
+
+def test_change_from_git_diff_name_status_with_none_name():
+    """Test Change.from_git_diff_name_status with None name."""
+    change = git.Change.from_git_diff_name_status(name=None, status="M")
+    assert change.a_path is None
+    assert change.b_path is None
+    assert change.status == git.GitStatus.MODIFIED
+
+
+def test_change_from_git_diff_name_status_rename_without_tab():
+    """Test Change.from_git_diff_name_status with rename status but no tab in name."""
+    change = git.Change.from_git_diff_name_status(name="file.py", status="R100")
+    assert change.a_path == "file.py"
+    assert change.b_path is None
+    assert change.status == git.GitStatus.RENAMED
+
+
+def test_changeset_from_diff_objs_with_none_a_path():
+    """Test ChangeSet.from_diff_objs with diff objects that have None a_path."""
+    # Create mock diff objects where a_path is None (new files)
+    diff1 = MagicMock(a_path=None, b_path="new_file.py", change_type="A")
+    diff2 = MagicMock(a_path="existing_file.py", b_path=None, change_type="M")
+
+    diffs = [diff1, diff2]
+    change_set = git.ChangeSet.from_diff_objs(diffs)
+
+    assert len(change_set.changes) == 2
+    assert change_set.changes[0].name == "new_file.py"  # Uses b_path when a_path is None
+    assert change_set.changes[1].name == "existing_file.py"  # Uses a_path when available
+
+
+@patch("pytest_impacted.git.Repo")
+def test_impacted_files_for_unstaged_mode_with_none_names(mock_repo):
+    """Test impacted_files_for_unstaged_mode with files that have None names."""
+    # Create diff objects where some have None names
+    diff1 = MagicMock(a_path="file1.py", b_path=None, change_type="M")
+    diff2 = MagicMock(a_path=None, b_path=None, change_type="D")  # This will have None name
+    diff_result = [diff1, diff2]
+
+    repo = DummyRepo(dirty=True, diff_result=diff_result, untracked_files=["untracked.py"])
+    result = git.impacted_files_for_unstaged_mode(repo)
+
+    # Should filter out None names and only include valid files
+    assert set(result) == {"file1.py", "untracked.py"}
+
+
+@patch("pytest_impacted.git.Repo")
+def test_impacted_files_for_branch_mode_with_none_names(mock_repo):
+    """Test impacted_files_for_branch_mode with files that have None names."""
+    # Create diff output that results in None names
+    diff_output = "M\tfile1.py\nD\t"  # Second line has empty filename
+
+    repo = DummyRepo(diff_branch_result=diff_output)
+    result = git.impacted_files_for_branch_mode(repo, "main")
+
+    # Should filter out None/empty names
+    assert result == ["file1.py"]
+
+
+def test_without_nones_with_mixed_types():
+    """Test without_nones with mixed types including None."""
+    items = [1, None, "string", None, [], {}, None]
+    result = git.without_nones(items)
+    assert result == [1, "string", [], {}]
+
+
+def test_git_status_from_git_diff_name_status_copy_and_rename():
+    """Test GitStatus.from_git_diff_name_status with copy and rename scores."""
+    # Test copy with score
+    assert git.GitStatus.from_git_diff_name_status("C100") == git.GitStatus.COPIED
+    assert git.GitStatus.from_git_diff_name_status("C85") == git.GitStatus.COPIED
+
+    # Test rename with score
+    assert git.GitStatus.from_git_diff_name_status("R100") == git.GitStatus.RENAMED
+    assert git.GitStatus.from_git_diff_name_status("R75") == git.GitStatus.RENAMED

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,8 +1,10 @@
 """Unit tests for the git module."""
 
-from unittest.mock import patch, MagicMock
-from pytest_impacted import git
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+from pytest_impacted import git
 
 
 class DummyRepo:
@@ -62,9 +64,7 @@ def test_find_impacted_files_in_repo_unstaged_dirty_with_untracked_files(mock_re
     diff1 = MagicMock(a_path="file1.py", b_path=None, change_type="M")
     diff2 = MagicMock(a_path=None, b_path="file2.py", change_type="A")
     diff_result = [diff1, diff2]
-    mock_repo.return_value = DummyRepo(
-        dirty=True, diff_result=diff_result, untracked_files=["file3.py", "file4.py"]
-    )
+    mock_repo.return_value = DummyRepo(dirty=True, diff_result=diff_result, untracked_files=["file3.py", "file4.py"])
     result = git.find_impacted_files_in_repo(".", git.GitMode.UNSTAGED, None)
     assert set(result) == {"file1.py", "file2.py", "file3.py", "file4.py"}
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,10 @@
 """Unit tests for the graph module."""
 
-import pytest
+from unittest.mock import MagicMock, patch
+
 import networkx as nx
-from unittest.mock import patch, MagicMock
+import pytest
+
 from pytest_impacted import graph
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,8 +1,10 @@
 """Unit tests for the parsing module."""
 
 import tempfile
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 from pytest_impacted import parsing
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,12 +1,14 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
+
+from pytest_impacted.git import GitMode
 from pytest_impacted.plugin import (
     pytest_addoption,
     pytest_configure,
     pytest_report_header,
     validate_config,
 )
-from pytest_impacted.git import GitMode
 
 
 @pytest.fixture
@@ -57,10 +59,7 @@ def test_pytest_configure(pytestconfig):
 
     # Check that the marker is added
     markers = pytestconfig.getini("markers")
-    assert (
-        "impacted(state): mark test as impacted by the state of the git repository"
-        in markers
-    )
+    assert "impacted(state): mark test as impacted by the state of the git repository" in markers
 
 
 def test_pytest_report_header(pytestconfig):

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -1,11 +1,11 @@
 """Tests for the traversal module."""
 
 import importlib
+import pkgutil
 import types
 from pathlib import Path
 
 import pytest
-import pkgutil
 
 from pytest_impacted.traversal import (
     import_submodules,
@@ -63,12 +63,7 @@ def test_resolve_files_to_modules():
     package_path = Path(importlib.import_module("pytest_impacted").__path__[0])
     test_file = str(package_path / "traversal.py")
     # Simulate the replacement logic
-    module_name = (
-        test_file.replace(str(package_path), "")
-        .replace("/", ".")
-        .replace(".py", "")
-        .lstrip(".")
-    )
+    module_name = test_file.replace(str(package_path), "").replace("/", ".").replace(".py", "").lstrip(".")
     submodules = import_submodules("pytest_impacted")
     modules = resolve_files_to_modules([test_file], "pytest_impacted")
     # The function will only return the module name if it matches a key in submodules
@@ -219,9 +214,7 @@ def test_resolve_files_to_modules_with_tests_package():
             if package == "pytest_impacted":
                 return {"traversal": types.ModuleType("traversal")}
             elif package == "tests":
-                return {
-                    "path.to.tests.test_traversal": types.ModuleType("test_traversal")
-                }
+                return {"path.to.tests.test_traversal": types.ModuleType("test_traversal")}
             return {}
 
         m.setattr("pytest_impacted.traversal.import_submodules", mock_import_submodules)


### PR DESCRIPTION
- add ruff linter and formatter settings in pyproject.toml, enable isort behavior, fix existing issues
- updates to impacted-tests CLI to support outputting names of impacted tests to stdout and logging/errors to stderr so can use as part of CI pipeline when piping to file output
- add cli module unit-test file
- add more unit-test coverage across the board
