### PR TITLE
fix breakage on changed files which correspond to dangling nodes in the dependency tree; add unit-test coverage

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -10,7 +10,9 @@ This is a repository that exposes a pytest plugin called `pytest-impact` which u
 
 ## Virtual Environment and Package Dependency Management
 
-We use `uv` for managing virtualenv and package dependencies. Dependencies can be added using the command-line:
+We use `uv` for managing virtualenv and package dependencies. All commands below should be run from the repository directory root.
+
+Dependencies can be added using the command-line:
 
     uv add <package_name>
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ this will run all unit-tests impacted by changes to files which have been
 modified via any existing commits to the current active branch, as compared to
 the base branch passed in the `--impacted-base-branch` parameter.
 
+As an added bonus, note that you can pass git expressions to the base branch parameter as would be permissible when using git diff - e.g.:
+
+ $ pytest --impacted --impacted-git-mode=branch --impacted-base-branch="HEAD~4" --impacted-module=<my_root_module_name>
+
+This can be useful in some scenarios as well.
+
 ### External tests directory
 
 As another common use case, In some projects the tests directory exists outside of the namespace package. In those cases you can use the `--impacted-tests-dir` option to make sure those test files are included in the dependency tree and correctly considered for impact analysis:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -28,22 +28,29 @@ def sample_dep_tree():
     return digraph
 
 
-def test_resolve_impacted_tests(sample_dep_tree):
-    """Test resolving impacted tests from modified modules."""
-    # Test single module modification
-    modified_modules = ["module_d"]
-    impacted = graph.resolve_impacted_tests(modified_modules, sample_dep_tree)
-    assert set(impacted) == {"test_module1", "test_module2"}
+@pytest.mark.parametrize(
+    "modified_modules,expected_impacted",
+    [
+        # Test single module modification
+        (["module_d"], {"test_module1", "test_module2"}),
+        # Test multiple module modifications
+        (["module_b", "module_c"], {"test_module1", "test_module2"}),
+        # Test no impact
+        (["module_e"], {"test_module2"}),
+        # Test dangling node (module not in dependency tree)
+        (["dangling_module"], set()),
+    ],
+)
+def test_resolve_impacted_tests(sample_dep_tree, modified_modules, expected_impacted):
+    """Test resolving impacted tests from modified modules.
 
-    # Test multiple module modifications
-    modified_modules = ["module_b", "module_c"]
+    Args:
+        sample_dep_tree: Fixture providing a sample dependency tree
+        modified_modules: List of modules that were modified
+        expected_impacted: Set of test modules expected to be impacted
+    """
     impacted = graph.resolve_impacted_tests(modified_modules, sample_dep_tree)
-    assert set(impacted) == {"test_module1", "test_module2"}
-
-    # Test no impact
-    modified_modules = ["module_e"]
-    impacted = graph.resolve_impacted_tests(modified_modules, sample_dep_tree)
-    assert set(impacted) == {"test_module2"}
+    assert set(impacted) == expected_impacted
 
 
 def test_build_dep_tree():


### PR DESCRIPTION
- fix breakage on changed files which correspond to dangling nodes in the dependency tree
- add unit-test coverage
- minor updates to `.cursorrules` file and `README.md`
- Release tag `0.11.0`