### PR TITLE
Add dependency file change detection, refactor strategy abstraction, add Python 3.14

### DIFF
--- a/.github/workflows/ci-impacted.yml
+++ b/.github/workflows/ci-impacted.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,5 +96,5 @@ The documentation site uses [MkDocs Material](https://squidfun.github.io/mkdocs-
 
 - Ruff: line-length=120, target-version=py311, double quote style, T201 (print) allowed
 - Pre-commit hooks: ruff, mypy, pytest with coverage (fail_fast: true)
-- CI matrix: Python 3.11, 3.12, 3.13
+- CI matrix: Python 3.11, 3.12, 3.13, 3.14
 - Python 3.11+ minimum required

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,7 @@ Impact analysis uses a strategy-based architecture defined in `strategies.py`:
 - **`DependencyFileImpactStrategy`**: Detects changes in dependency/config files (`uv.lock`, `requirements.txt`, `pyproject.toml`, `Pipfile.lock`, `poetry.lock`, `setup.py`, `setup.cfg`, `requirements/*.txt`) and marks all test modules as impacted. Accepts custom patterns via constructor. Enabled by default; disable with `--no-impacted-dep-files`
 - **`CompositeImpactStrategy`**: Combines multiple strategies, deduplicates and sorts results
 
-The default strategy in `api.py` is `CompositeImpactStrategy([ASTImpactStrategy(), PytestImpactStrategy(), DependencyFileImpactStrategy()])`.
-
-Helper functions `has_dependency_file_changes()` and `_matches_dependency_file()` in `strategies.py` provide the dependency file pattern matching, also used in `api.py` to bypass the early-return guard when no Python modules but dependency files are detected among changed files.
+The default strategy composition is built by `get_default_strategies()` in `strategies.py` and wrapped in `CompositeImpactStrategy` by `api.py`. The orchestrator (`api.py`) has no strategy-specific logic—it always passes `changed_files` and `impacted_modules` (which may be empty) to the composite, and each strategy decides what to do. This means strategies like `DependencyFileImpactStrategy` that operate on non-Python files work naturally without special-casing in the orchestrator.
 
 Dependency tree building uses an LRU cache (`_cached_build_dep_tree` in `strategies.py`, maxsize=8) with `clear_dep_tree_cache()` for invalidation (also clears `discover_submodules` cache).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,15 +66,18 @@ Impact analysis uses a strategy-based architecture defined in `strategies.py`:
 - **`ImpactStrategy`** (ABC): Base class defining `find_impacted_tests()` interface
 - **`ASTImpactStrategy`**: Default strategy using AST parsing and dependency graph traversal
 - **`PytestImpactStrategy`**: Extends AST analysis with pytest-specific handling—when `conftest.py` files change, all tests in the same directory and subdirectories are considered impacted
+- **`DependencyFileImpactStrategy`**: Detects changes in dependency/config files (`uv.lock`, `requirements.txt`, `pyproject.toml`, `Pipfile.lock`, `poetry.lock`, `setup.py`, `setup.cfg`, `requirements/*.txt`) and marks all test modules as impacted. Accepts custom patterns via constructor. Enabled by default; disable with `--no-impacted-dep-files`
 - **`CompositeImpactStrategy`**: Combines multiple strategies, deduplicates and sorts results
 
-The default strategy in `api.py` is `CompositeImpactStrategy([ASTImpactStrategy(), PytestImpactStrategy()])`.
+The default strategy in `api.py` is `CompositeImpactStrategy([ASTImpactStrategy(), PytestImpactStrategy(), DependencyFileImpactStrategy()])`.
+
+Helper functions `has_dependency_file_changes()` and `_matches_dependency_file()` in `strategies.py` provide the dependency file pattern matching, also used in `api.py` to bypass the early-return guard when no Python modules but dependency files are detected among changed files.
 
 Dependency tree building uses an LRU cache (`_cached_build_dep_tree` in `strategies.py`, maxsize=8) with `clear_dep_tree_cache()` for invalidation (also clears `discover_submodules` cache).
 
 ### Test Structure
 
-Tests mirror the source structure. The `tests/strategies/` subdirectory contains per-strategy tests (`test_ast_impact.py`, `test_pytest_impact.py`, `test_composite_impact.py`, `test_caching.py`, `test_integration.py`). Tests use `unittest.mock` extensively and the `pytester` pytest plugin (enabled in `conftest.py`) for testing plugin behavior. Some tests are marked `@pytest.mark.slow`.
+Tests mirror the source structure. The `tests/strategies/` subdirectory contains per-strategy tests (`test_ast_impact.py`, `test_pytest_impact.py`, `test_composite_impact.py`, `test_dependency_file_impact.py`, `test_caching.py`, `test_integration.py`). Tests use `unittest.mock` extensively and the `pytester` pytest plugin (enabled in `conftest.py`) for testing plugin behavior. Some tests are marked `@pytest.mark.slow`.
 
 ## Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ pre-commit run --all-files
 
 ## Core Architecture
 
-The pipeline: Git identifies changed files → Files converted to Python modules → AST parser builds dependency graph → Graph analysis finds impacted test modules → Tests are filtered.
+The pipeline: Git identifies changed files → Files converted to Python modules → AST parser builds dependency graph → Graph analysis finds impacted test modules → Tests are filtered. In parallel, dependency file changes (e.g. `uv.lock`, `requirements.txt`) trigger all tests via `DependencyFileImpactStrategy`.
 
 ### Module Responsibilities
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pytest --impacted --impacted-module=my_package \
 | :gear: | **No imports at analysis time** | Filesystem discovery + AST parsing — no module-level side effects |
 | :test_tube: | **pytest-native** | Works as a standard pytest plugin with familiar CLI options |
 | :wrench: | **conftest.py aware** | Changes to `conftest.py` automatically impact all tests in scope |
+| :package: | **Dependency-file aware** | Changes to `uv.lock`, `requirements.txt`, `pyproject.toml` etc. trigger all tests |
 | :building_construction: | **CI-friendly** | Standalone `impacted-tests` CLI for two-stage CI pipelines |
 | :shield: | **Helpful errors** | Validates config early with clear messages and suggestions |
 
@@ -100,8 +101,9 @@ Impact analysis is pluggable via a strategy pattern. The default pipeline combin
 |----------|-------------|
 | **ASTImpactStrategy** | Traces transitive import dependencies through the dependency graph |
 | **PytestImpactStrategy** | Extends AST analysis with pytest-specific knowledge — when a `conftest.py` file changes, **all tests in its directory and subdirectories** are marked as impacted |
+| **DependencyFileImpactStrategy** | When dependency files change (`uv.lock`, `requirements.txt`, `pyproject.toml`, etc.), **all tests** are marked as impacted |
 
-Both strategies are combined via `CompositeImpactStrategy`, which deduplicates and merges their results. This is important because `conftest.py` files are implicitly loaded by pytest at runtime and are not visible through normal import analysis.
+All strategies are combined via `CompositeImpactStrategy`, which deduplicates and merges their results. Dependency file detection is enabled by default and can be disabled with `--no-impacted-dep-files`.
 
 You can also supply a custom strategy via the `get_impacted_tests()` API:
 
@@ -197,6 +199,7 @@ CLI flags override these defaults.
 | `--impacted-git-mode` | `unstaged` | Git comparison mode: `unstaged` or `branch` |
 | `--impacted-base-branch` | *(required for branch mode)* | Base branch/ref for branch-mode comparison |
 | `--impacted-tests-dir` | `None` | Directory containing tests outside the package |
+| `--no-impacted-dep-files` | `false` | Disable dependency file change detection |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,19 +83,21 @@ That's it. Unaffected tests are automatically skipped.
 
 ```
 Git diff → Changed files → Module resolution → AST import parsing → Dependency graph → Impacted tests
+                         ↘ Dependency file detection → All tests (if dep files changed)
 ```
 
 1. **Git introspection** identifies which files changed (unstaged edits or branch diff)
 2. **Filesystem discovery** maps file paths to Python module names — without importing anything
 3. **AST parsing** (via [astroid](https://pylint.pycqa.org/projects/astroid/en/latest/)) extracts import relationships from source files
 4. **Dependency graph** (via [NetworkX](https://networkx.org/)) traces transitive dependencies from changed modules to test modules
-5. **Test filtering** skips tests whose modules are not in the impact set
+5. **Dependency file detection** — if files like `uv.lock`, `requirements.txt`, or `pyproject.toml` changed, all tests are marked as impacted regardless of import analysis
+6. **Test filtering** skips tests whose modules are not in the impact set
 
 The philosophy is to **err on the side of caution**: we favor false positives (running a test that didn't need to run) over false negatives (missing a test that should have run).
 
 ### Strategy-Based Architecture
 
-Impact analysis is pluggable via a strategy pattern. The default pipeline combines two strategies:
+Impact analysis is pluggable via a strategy pattern. The default pipeline combines three strategies:
 
 | Strategy | What it does |
 |----------|-------------|
@@ -186,6 +188,7 @@ impacted_module = "my_package"
 impacted_git_mode = "branch"
 impacted_base_branch = "main"
 impacted_tests_dir = "tests"
+# no_impacted_dep_files = true  # uncomment to disable dep file detection
 ```
 
 CLI flags override these defaults.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,6 +108,26 @@ Extends the AST analysis with pytest-specific dependency detection:
 - **`conftest.py` handling**: When a `conftest.py` file is modified, all tests in the same directory and subdirectories are considered impacted. This is critical because `conftest.py` files are implicitly loaded by pytest at runtime and are **not visible through normal import analysis**.
 - Designed to be extended with additional pytest-specific heuristics in the future.
 
+### DependencyFileImpactStrategy
+
+Detects changes in dependency and configuration files. When these files change, any test could potentially be affected — so **all test modules are marked as impacted**.
+
+Monitored files include:
+
+- `uv.lock`, `requirements.txt`, `pyproject.toml`
+- `Pipfile`, `Pipfile.lock`, `poetry.lock`
+- `setup.py`, `setup.cfg`
+- `requirements/*.txt` (nested requirements files)
+
+This strategy is enabled by default. To disable it, use:
+
+```bash
+pytest --impacted --impacted-module=my_package --no-impacted-dep-files
+```
+
+!!! tip
+    This is especially useful in CI where dependency version bumps (e.g. updating `uv.lock`) don't change any `.py` files but could still break tests due to changed third-party behavior.
+
 ### CompositeImpactStrategy
 
 Combines multiple strategies, deduplicating and sorting results. The default composition is:
@@ -116,6 +136,7 @@ Combines multiple strategies, deduplicating and sorting results. The default com
 CompositeImpactStrategy([
     ASTImpactStrategy(),
     PytestImpactStrategy(),
+    DependencyFileImpactStrategy(),
 ])
 ```
 
@@ -165,6 +186,7 @@ impacted_module = "my_package"
 impacted_git_mode = "branch"
 impacted_base_branch = "main"
 impacted_tests_dir = "tests"
+no_impacted_dep_files = false  # set to true to disable dep file detection
 ```
 
 CLI flags override these defaults.
@@ -191,6 +213,7 @@ The plugin validates configuration early and provides helpful error messages:
 | `--impacted-git-mode` | `unstaged` | Git comparison mode: `unstaged` or `branch` |
 | `--impacted-base-branch` | *(required for branch mode)* | Base branch/ref for branch-mode comparison |
 | `--impacted-tests-dir` | `None` | Directory containing tests outside the package |
+| `--no-impacted-dep-files` | `false` | Disable dependency file change detection |
 
 ## How It Works (Pipeline)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,7 +90,7 @@ Run pytest from the `backend/` directory as usual. The plugin will:
 
 ## Impact Analysis Strategies
 
-The plugin uses a modular, strategy-based architecture to determine which tests are affected by code changes. Strategies are composable — the default pipeline combines two built-in strategies.
+The plugin uses a modular, strategy-based architecture to determine which tests are affected by code changes. Strategies are composable — the default pipeline combines three built-in strategies.
 
 ### ASTImpactStrategy
 
@@ -223,13 +223,16 @@ graph LR
     B --> C[Module resolution]
     C --> D[AST import parsing]
     D --> E[Dependency graph]
-    E --> F[Impacted tests]
+    E --> G[Impacted tests]
+    B --> F[Dep file detection]
+    F -->|uv.lock, requirements.txt, etc.| G
 ```
 
 1. **Git introspection** identifies which files changed (unstaged edits or branch diff)
 2. **Filesystem discovery** maps file paths to Python module names — without importing anything
 3. **AST parsing** (via [astroid](https://pylint.pycqa.org/projects/astroid/en/latest/)) extracts import relationships from source files
 4. **Dependency graph** (via [NetworkX](https://networkx.org/)) traces transitive dependencies from changed modules to test modules
-5. **Test filtering** skips tests whose modules are not in the impact set
+5. **Dependency file detection** — if files like `uv.lock`, `requirements.txt`, or `pyproject.toml` changed, all tests are marked as impacted regardless of import analysis
+6. **Test filtering** skips tests whose modules are not in the impact set
 
 The philosophy is to **err on the side of caution**: false positives (running a test that didn't need to run) are preferred over false negatives (missing a test that should have run).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",

--- a/pytest_impacted/api.py
+++ b/pytest_impacted/api.py
@@ -8,8 +8,10 @@ from pytest_impacted.git import GitMode, find_impacted_files_in_repo
 from pytest_impacted.strategies import (
     ASTImpactStrategy,
     CompositeImpactStrategy,
+    DependencyFileImpactStrategy,
     ImpactStrategy,
     PytestImpactStrategy,
+    has_dependency_file_changes,
 )
 from pytest_impacted.traversal import (
     path_to_package_name,
@@ -31,6 +33,7 @@ def get_impacted_tests(
     tests_dir: str | None = None,
     session=None,
     strategy: ImpactStrategy | None = None,
+    watch_dep_files: bool = True,
 ) -> list[str] | None:
     """Get the list of impacted tests based on the git state and static analysis."""
     git_mode = impacted_git_mode
@@ -38,12 +41,13 @@ def get_impacted_tests(
 
     # Use default strategy if none provided
     if strategy is None:
-        strategy = CompositeImpactStrategy(
-            [
-                ASTImpactStrategy(),
-                PytestImpactStrategy(),
-            ]
-        )
+        strategies: list[ImpactStrategy] = [
+            ASTImpactStrategy(),
+            PytestImpactStrategy(),
+        ]
+        if watch_dep_files:
+            strategies.append(DependencyFileImpactStrategy())
+        strategy = CompositeImpactStrategy(strategies)
 
     tests_package = None
     if tests_dir:
@@ -69,11 +73,19 @@ def get_impacted_tests(
 
     impacted_modules = resolve_files_to_modules(impacted_files, ns_module=ns_module, tests_package=tests_package)
     if not impacted_modules:
-        notify(
-            f"No impacted Python modules detected. Impacted files were: {impacted_files}",
-            session,
-        )
-        return None
+        # Check if dependency file changes should keep the pipeline running
+        if watch_dep_files and has_dependency_file_changes(impacted_files):
+            notify(
+                f"No impacted Python modules detected, but dependency file changes found in: {impacted_files}. "
+                "Continuing to strategy pipeline.",
+                session,
+            )
+        else:
+            notify(
+                f"No impacted Python modules detected. Impacted files were: {impacted_files}",
+                session,
+            )
+            return None
 
     # Use the strategy to find impacted test modules
     impacted_test_modules = strategy.find_impacted_tests(

--- a/pytest_impacted/api.py
+++ b/pytest_impacted/api.py
@@ -6,12 +6,9 @@ from pathlib import Path
 from pytest_impacted.display import notify, warn
 from pytest_impacted.git import GitMode, find_impacted_files_in_repo
 from pytest_impacted.strategies import (
-    ASTImpactStrategy,
     CompositeImpactStrategy,
-    DependencyFileImpactStrategy,
     ImpactStrategy,
-    PytestImpactStrategy,
-    has_dependency_file_changes,
+    get_default_strategies,
 )
 from pytest_impacted.traversal import (
     path_to_package_name,
@@ -41,13 +38,7 @@ def get_impacted_tests(
 
     # Use default strategy if none provided
     if strategy is None:
-        strategies: list[ImpactStrategy] = [
-            ASTImpactStrategy(),
-            PytestImpactStrategy(),
-        ]
-        if watch_dep_files:
-            strategies.append(DependencyFileImpactStrategy())
-        strategy = CompositeImpactStrategy(strategies)
+        strategy = CompositeImpactStrategy(get_default_strategies(watch_dep_files=watch_dep_files))
 
     tests_package = None
     if tests_dir:
@@ -73,19 +64,11 @@ def get_impacted_tests(
 
     impacted_modules = resolve_files_to_modules(impacted_files, ns_module=ns_module, tests_package=tests_package)
     if not impacted_modules:
-        # Check if dependency file changes should keep the pipeline running
-        if watch_dep_files and has_dependency_file_changes(impacted_files):
-            notify(
-                f"No impacted Python modules detected, but dependency file changes found in: {impacted_files}. "
-                "Continuing to strategy pipeline.",
-                session,
-            )
-        else:
-            notify(
-                f"No impacted Python modules detected. Impacted files were: {impacted_files}",
-                session,
-            )
-            return None
+        notify(
+            f"No impacted Python modules detected. Impacted files were: {impacted_files}. "
+            "Continuing to strategy pipeline.",
+            session,
+        )
 
     # Use the strategy to find impacted test modules
     impacted_test_modules = strategy.find_impacted_tests(

--- a/pytest_impacted/cli.py
+++ b/pytest_impacted/cli.py
@@ -46,7 +46,8 @@ def configure_logging(verbose: bool) -> None:
     ),
 )
 @click.option("--verbose", is_flag=True, help="Verbose output.")
-def impacted_tests_cli(git_mode, base_branch, root_dir, module, tests_dir, verbose):
+@click.option("--no-dep-files", is_flag=True, default=False, help="Disable dependency file change detection.")
+def impacted_tests_cli(git_mode, base_branch, root_dir, module, tests_dir, verbose, no_dep_files):
     """CLI entrypoint for impacted-tests console script."""
     click.echo("impacted-tests", err=True)
     click.secho("  base-branch: {}".format(base_branch), fg="blue", bold=True, err=True)
@@ -54,6 +55,7 @@ def impacted_tests_cli(git_mode, base_branch, root_dir, module, tests_dir, verbo
     click.secho("  module: {}".format(module), fg="blue", bold=True, err=True)
     click.secho("  root-dir: {}".format(root_dir), fg="blue", bold=True, err=True)
     click.secho("  tests-dir: {}".format(tests_dir), fg="blue", bold=True, err=True)
+    click.secho("  no-dep-files: {}".format(no_dep_files), fg="blue", bold=True, err=True)
 
     configure_logging(verbose=verbose)
 
@@ -63,6 +65,7 @@ def impacted_tests_cli(git_mode, base_branch, root_dir, module, tests_dir, verbo
         root_dir=root_dir,
         ns_module=module,
         tests_dir=tests_dir,
+        watch_dep_files=not no_dep_files,
     )
 
     if impacted_tests:

--- a/pytest_impacted/plugin.py
+++ b/pytest_impacted/plugin.py
@@ -85,6 +85,19 @@ def pytest_addoption(parser: Parser):
         default=None,
     )
 
+    group.addoption(
+        "--no-impacted-dep-files",
+        action="store_true",
+        default=None,
+        dest="no_impacted_dep_files",
+        help="Disable dependency file change detection (uv.lock, requirements.txt, etc.).",
+    )
+    parser.addini(
+        "no_impacted_dep_files",
+        help="default value for --no-impacted-dep-files",
+        default=False,
+    )
+
 
 def pytest_configure(config: Config):
     """pytest hook to configure the plugin.
@@ -109,6 +122,7 @@ def pytest_report_header(config: Config) -> list[str]:
         f"impacted_git_mode={get_option('impacted_git_mode')}",
         f"impacted_base_branch={get_option('impacted_base_branch')}",
         f"impacted_tests_dir={get_option('impacted_tests_dir')}",
+        f"no_impacted_dep_files={get_option('no_impacted_dep_files')}",
     ]
     return [
         "pytest-impacted: " + ", ".join(header),
@@ -131,6 +145,7 @@ def pytest_collection_modifyitems(session, config, items):
     impacted_git_mode = get_option("impacted_git_mode")
     impacted_base_branch = get_option("impacted_base_branch")
     impacted_tests_dir = get_option("impacted_tests_dir")
+    no_dep_files = get_option("no_impacted_dep_files")
     root_dir = config.rootdir
 
     impacted_tests = get_impacted_tests(
@@ -140,6 +155,7 @@ def pytest_collection_modifyitems(session, config, items):
         ns_module=ns_module,
         tests_dir=impacted_tests_dir,
         session=session,
+        watch_dep_files=not no_dep_files,
     )
     if not impacted_tests:
         # skip all tests

--- a/pytest_impacted/strategies.py
+++ b/pytest_impacted/strategies.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import networkx as nx
@@ -10,6 +10,46 @@ import networkx as nx
 from pytest_impacted.graph import build_dep_tree, resolve_impacted_tests
 from pytest_impacted.parsing import is_test_module, normalize_path
 from pytest_impacted.traversal import discover_submodules
+
+
+# Default dependency file basenames that trigger all tests when changed
+DEFAULT_DEPENDENCY_FILE_PATTERNS: tuple[str, ...] = (
+    "uv.lock",
+    "requirements.txt",
+    "pyproject.toml",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "setup.py",
+    "setup.cfg",
+)
+
+# Glob-style patterns for matching nested dependency files (e.g. requirements/*.txt)
+DEFAULT_DEPENDENCY_GLOB_PATTERNS: tuple[str, ...] = (
+    "requirements/*.txt",
+    "requirements/**/*.txt",
+)
+
+
+def _matches_dependency_file(
+    file_path: str,
+    patterns: tuple[str, ...] = DEFAULT_DEPENDENCY_FILE_PATTERNS,
+    glob_patterns: tuple[str, ...] = DEFAULT_DEPENDENCY_GLOB_PATTERNS,
+) -> bool:
+    """Check if a file path matches any dependency file pattern."""
+    basename = PurePosixPath(file_path).name
+    if basename in patterns:
+        return True
+    return any(PurePosixPath(file_path).match(glob_pat) for glob_pat in glob_patterns)
+
+
+def has_dependency_file_changes(
+    changed_files: list[str],
+    patterns: tuple[str, ...] = DEFAULT_DEPENDENCY_FILE_PATTERNS,
+    glob_patterns: tuple[str, ...] = DEFAULT_DEPENDENCY_GLOB_PATTERNS,
+) -> bool:
+    """Check if any changed files are dependency/configuration files."""
+    return any(_matches_dependency_file(f, patterns, glob_patterns) for f in changed_files)
 
 
 @lru_cache(maxsize=8)
@@ -174,6 +214,51 @@ class PytestImpactStrategy(ImpactStrategy):
                     continue
 
         return False
+
+
+class DependencyFileImpactStrategy(ImpactStrategy):
+    """Strategy that triggers all tests when dependency files change.
+
+    When files like uv.lock, requirements.txt, pyproject.toml etc. are
+    modified, any test could potentially be affected. This strategy
+    conservatively marks all discovered test modules as impacted.
+    """
+
+    def __init__(
+        self,
+        patterns: tuple[str, ...] = DEFAULT_DEPENDENCY_FILE_PATTERNS,
+        glob_patterns: tuple[str, ...] = DEFAULT_DEPENDENCY_GLOB_PATTERNS,
+    ):
+        self.patterns = patterns
+        self.glob_patterns = glob_patterns
+
+    def find_impacted_tests(
+        self,
+        changed_files: list[str],
+        impacted_modules: list[str],
+        ns_module: str,
+        tests_package: str | None = None,
+        root_dir: Path | None = None,
+        session: Any = None,
+    ) -> list[str]:
+        """Return all test modules if dependency files have changed."""
+        if not has_dependency_file_changes(changed_files, self.patterns, self.glob_patterns):
+            return []
+
+        # Build the dep tree to discover all test modules
+        dep_tree = _cached_build_dep_tree(ns_module, tests_package=tests_package)
+        all_test_modules = sorted(node for node in dep_tree.nodes if is_test_module(node))
+
+        dep_files = [f for f in changed_files if _matches_dependency_file(f, self.patterns, self.glob_patterns)]
+        from pytest_impacted.display import notify  # noqa: PLC0415
+
+        notify(
+            f"Dependency file changes detected: {dep_files}. "
+            f"Marking all {len(all_test_modules)} test modules as impacted.",
+            session,
+        )
+
+        return all_test_modules
 
 
 class CompositeImpactStrategy(ImpactStrategy):

--- a/pytest_impacted/strategies.py
+++ b/pytest_impacted/strategies.py
@@ -261,6 +261,21 @@ class DependencyFileImpactStrategy(ImpactStrategy):
         return all_test_modules
 
 
+def get_default_strategies(*, watch_dep_files: bool = True) -> list[ImpactStrategy]:
+    """Return the default strategy list for impact analysis.
+
+    This centralizes the knowledge of which strategies form the default
+    pipeline. Add new strategies here rather than in api.py.
+    """
+    strategies: list[ImpactStrategy] = [
+        ASTImpactStrategy(),
+        PytestImpactStrategy(),
+    ]
+    if watch_dep_files:
+        strategies.append(DependencyFileImpactStrategy())
+    return strategies
+
+
 class CompositeImpactStrategy(ImpactStrategy):
     """Strategy that combines multiple strategies."""
 

--- a/tests/strategies/test_composite_impact.py
+++ b/tests/strategies/test_composite_impact.py
@@ -3,8 +3,12 @@
 from unittest.mock import MagicMock
 
 from pytest_impacted.strategies import (
+    ASTImpactStrategy,
     CompositeImpactStrategy,
+    DependencyFileImpactStrategy,
     ImpactStrategy,
+    PytestImpactStrategy,
+    get_default_strategies,
 )
 
 
@@ -66,3 +70,30 @@ class TestCompositeImpactStrategy:
 
         assert result == ["test_a"]
         strategy.find_impacted_tests.assert_called_once()
+
+
+class TestGetDefaultStrategies:
+    """Test the get_default_strategies factory function."""
+
+    def test_default_includes_all_three_strategies(self):
+        """Default composition includes AST, Pytest, and DependencyFile strategies."""
+        strategies = get_default_strategies()
+        assert len(strategies) == 3
+        assert isinstance(strategies[0], ASTImpactStrategy)
+        assert isinstance(strategies[1], PytestImpactStrategy)
+        assert isinstance(strategies[2], DependencyFileImpactStrategy)
+
+    def test_watch_dep_files_false_excludes_dependency_strategy(self):
+        """When watch_dep_files=False, DependencyFileImpactStrategy is excluded."""
+        strategies = get_default_strategies(watch_dep_files=False)
+        assert len(strategies) == 2
+        assert isinstance(strategies[0], ASTImpactStrategy)
+        assert isinstance(strategies[1], PytestImpactStrategy)
+        assert not any(isinstance(s, DependencyFileImpactStrategy) for s in strategies)
+
+    def test_returns_new_instances_each_call(self):
+        """Each call should return fresh strategy instances."""
+        strategies_a = get_default_strategies()
+        strategies_b = get_default_strategies()
+        assert strategies_a is not strategies_b
+        assert strategies_a[0] is not strategies_b[0]

--- a/tests/strategies/test_dependency_file_impact.py
+++ b/tests/strategies/test_dependency_file_impact.py
@@ -1,0 +1,203 @@
+"""Unit-tests for the dependency file impact strategy module."""
+
+from unittest.mock import patch
+
+import networkx as nx
+
+from pytest_impacted.strategies import (
+    DependencyFileImpactStrategy,
+    _matches_dependency_file,
+    has_dependency_file_changes,
+)
+
+
+class TestMatchesDependencyFile:
+    """Test the _matches_dependency_file helper function."""
+
+    def test_matches_uv_lock(self):
+        assert _matches_dependency_file("uv.lock") is True
+
+    def test_matches_uv_lock_in_subdirectory(self):
+        assert _matches_dependency_file("project/uv.lock") is True
+
+    def test_matches_requirements_txt(self):
+        assert _matches_dependency_file("requirements.txt") is True
+
+    def test_matches_pyproject_toml(self):
+        assert _matches_dependency_file("pyproject.toml") is True
+
+    def test_matches_pipfile(self):
+        assert _matches_dependency_file("Pipfile") is True
+
+    def test_matches_pipfile_lock(self):
+        assert _matches_dependency_file("Pipfile.lock") is True
+
+    def test_matches_poetry_lock(self):
+        assert _matches_dependency_file("poetry.lock") is True
+
+    def test_matches_setup_py(self):
+        assert _matches_dependency_file("setup.py") is True
+
+    def test_matches_setup_cfg(self):
+        assert _matches_dependency_file("setup.cfg") is True
+
+    def test_matches_nested_requirements(self):
+        assert _matches_dependency_file("requirements/prod.txt") is True
+
+    def test_matches_deeply_nested_requirements(self):
+        assert _matches_dependency_file("requirements/sub/dev.txt") is True
+
+    def test_no_match_regular_py_file(self):
+        assert _matches_dependency_file("src/module.py") is False
+
+    def test_no_match_similar_name(self):
+        """Basename must be exact — 'my_requirements.txt' should not match."""
+        assert _matches_dependency_file("my_requirements.txt") is False
+
+    def test_no_match_non_txt_in_requirements_dir(self):
+        assert _matches_dependency_file("requirements/README.md") is False
+
+    def test_custom_patterns(self):
+        assert _matches_dependency_file("custom.lock", patterns=("custom.lock",), glob_patterns=()) is True
+        assert _matches_dependency_file("uv.lock", patterns=("custom.lock",), glob_patterns=()) is False
+
+
+class TestHasDependencyFileChanges:
+    """Test the has_dependency_file_changes function."""
+
+    def test_returns_true_when_dep_file_present(self):
+        changed_files = ["src/module.py", "uv.lock", "tests/test_foo.py"]
+        assert has_dependency_file_changes(changed_files) is True
+
+    def test_returns_false_when_no_dep_files(self):
+        changed_files = ["src/module.py", "tests/test_foo.py"]
+        assert has_dependency_file_changes(changed_files) is False
+
+    def test_returns_false_for_empty_list(self):
+        assert has_dependency_file_changes([]) is False
+
+    def test_returns_true_for_only_dep_files(self):
+        assert has_dependency_file_changes(["uv.lock"]) is True
+
+    def test_uses_custom_patterns(self):
+        assert has_dependency_file_changes(["uv.lock"], patterns=(), glob_patterns=()) is False
+        assert has_dependency_file_changes(["custom.lock"], patterns=("custom.lock",), glob_patterns=()) is True
+
+
+class TestDependencyFileImpactStrategy:
+    """Test the DependencyFileImpactStrategy."""
+
+    def _make_dep_tree(self, nodes: list[str]) -> nx.DiGraph:
+        """Create a simple dependency graph with the given nodes."""
+        graph = nx.DiGraph()
+        graph.add_nodes_from(nodes)
+        return graph
+
+    @patch("pytest_impacted.strategies._cached_build_dep_tree")
+    def test_returns_all_tests_when_dep_file_changed(self, mock_build_dep_tree):
+        """When a dependency file changes, all test modules should be returned."""
+        mock_build_dep_tree.return_value = self._make_dep_tree(
+            ["mypackage.api", "mypackage.utils", "tests.test_api", "tests.test_utils"]
+        )
+
+        strategy = DependencyFileImpactStrategy()
+        result = strategy.find_impacted_tests(
+            changed_files=["uv.lock"],
+            impacted_modules=[],
+            ns_module="mypackage",
+            tests_package="tests",
+        )
+
+        assert result == ["tests.test_api", "tests.test_utils"]
+
+    @patch("pytest_impacted.strategies._cached_build_dep_tree")
+    def test_returns_empty_when_no_dep_file_changed(self, mock_build_dep_tree):
+        """When no dependency files changed, should return empty list."""
+        strategy = DependencyFileImpactStrategy()
+        result = strategy.find_impacted_tests(
+            changed_files=["src/module.py"],
+            impacted_modules=["mypackage.module"],
+            ns_module="mypackage",
+        )
+
+        assert result == []
+        # Dep tree should not even be built
+        mock_build_dep_tree.assert_not_called()
+
+    @patch("pytest_impacted.strategies._cached_build_dep_tree")
+    def test_works_with_empty_impacted_modules(self, mock_build_dep_tree):
+        """The key scenario: only dep files changed, so impacted_modules is empty."""
+        mock_build_dep_tree.return_value = self._make_dep_tree(["mypackage.core", "tests.test_core"])
+
+        strategy = DependencyFileImpactStrategy()
+        result = strategy.find_impacted_tests(
+            changed_files=["pyproject.toml", "uv.lock"],
+            impacted_modules=[],  # No .py files changed
+            ns_module="mypackage",
+            tests_package="tests",
+        )
+
+        assert result == ["tests.test_core"]
+
+    @patch("pytest_impacted.strategies._cached_build_dep_tree")
+    def test_custom_patterns(self, mock_build_dep_tree):
+        """Custom patterns should be used instead of defaults."""
+        mock_build_dep_tree.return_value = self._make_dep_tree(["mypackage.api", "tests.test_api"])
+
+        strategy = DependencyFileImpactStrategy(
+            patterns=("custom.lock",),
+            glob_patterns=(),
+        )
+
+        # Default patterns should not trigger
+        result = strategy.find_impacted_tests(
+            changed_files=["uv.lock"],
+            impacted_modules=[],
+            ns_module="mypackage",
+            tests_package="tests",
+        )
+        assert result == []
+
+        # Custom pattern should trigger
+        result = strategy.find_impacted_tests(
+            changed_files=["custom.lock"],
+            impacted_modules=[],
+            ns_module="mypackage",
+            tests_package="tests",
+        )
+        assert result == ["tests.test_api"]
+
+    @patch("pytest_impacted.strategies._cached_build_dep_tree")
+    def test_mixed_dep_and_py_changes(self, mock_build_dep_tree):
+        """When both dep files and .py files change, all tests should be returned."""
+        mock_build_dep_tree.return_value = self._make_dep_tree(
+            ["mypackage.api", "mypackage.utils", "tests.test_api", "tests.test_utils"]
+        )
+
+        strategy = DependencyFileImpactStrategy()
+        result = strategy.find_impacted_tests(
+            changed_files=["src/api.py", "requirements.txt"],
+            impacted_modules=["mypackage.api"],
+            ns_module="mypackage",
+            tests_package="tests",
+        )
+
+        # All tests returned because requirements.txt changed
+        assert result == ["tests.test_api", "tests.test_utils"]
+
+    @patch("pytest_impacted.strategies._cached_build_dep_tree")
+    def test_results_are_sorted(self, mock_build_dep_tree):
+        """Results should be sorted alphabetically."""
+        mock_build_dep_tree.return_value = self._make_dep_tree(
+            ["pkg.mod", "tests.test_z", "tests.test_a", "tests.test_m"]
+        )
+
+        strategy = DependencyFileImpactStrategy()
+        result = strategy.find_impacted_tests(
+            changed_files=["uv.lock"],
+            impacted_modules=[],
+            ns_module="pkg",
+            tests_package="tests",
+        )
+
+        assert result == ["tests.test_a", "tests.test_m", "tests.test_z"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -225,3 +225,88 @@ def test_get_impacted_tests_with_nested_tests_dir(mock_find_impacted_files):
 
         # path_to_package_name should not be called since no impacted files
         # but verify the function doesn't crash with nested paths
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+@patch("pytest_impacted.api.resolve_modules_to_files")
+def test_get_impacted_tests_dep_file_only_change(
+    mock_resolve_modules_to_files,
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """When only dependency files changed, all tests should be returned (not None)."""
+    mock_find_impacted_files.return_value = ["uv.lock"]
+    mock_resolve_files_to_modules.return_value = []  # No .py files -> no modules
+
+    # Create a mock strategy that returns all test modules when dep files detected
+    mock_strategy = MagicMock()
+    mock_strategy.find_impacted_tests.return_value = ["test_module1", "test_module2"]
+    mock_resolve_modules_to_files.return_value = ["test_file1.py", "test_file2.py"]
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir="tests",
+        strategy=mock_strategy,
+        watch_dep_files=True,
+    )
+
+    # Should NOT return None — dep file change keeps the pipeline running
+    assert result == ["test_file1.py", "test_file2.py"]
+    mock_strategy.find_impacted_tests.assert_called_once()
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+def test_get_impacted_tests_dep_file_with_watch_disabled(
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """When watch_dep_files=False, dep-only changes should return None."""
+    mock_find_impacted_files.return_value = ["uv.lock"]
+    mock_resolve_files_to_modules.return_value = []
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        watch_dep_files=False,
+    )
+
+    assert result is None
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+@patch("pytest_impacted.api.resolve_modules_to_files")
+def test_get_impacted_tests_mixed_dep_and_py_changes(
+    mock_resolve_modules_to_files,
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """Both dep files and .py files changed — strategy should receive all changed files."""
+    mock_find_impacted_files.return_value = ["src/module.py", "uv.lock"]
+    mock_resolve_files_to_modules.return_value = ["mypackage.module"]
+    mock_resolve_modules_to_files.return_value = ["test_file1.py", "test_file2.py"]
+
+    mock_strategy = MagicMock()
+    mock_strategy.find_impacted_tests.return_value = ["test_module1", "test_module2"]
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir="tests",
+        strategy=mock_strategy,
+    )
+
+    assert result == ["test_file1.py", "test_file2.py"]
+    # Strategy should receive all changed files including uv.lock
+    call_args = mock_strategy.find_impacted_tests.call_args
+    assert "uv.lock" in call_args.kwargs["changed_files"]
+    assert "src/module.py" in call_args.kwargs["changed_files"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -235,11 +235,14 @@ def test_get_impacted_tests_dep_file_only_change(
     mock_resolve_files_to_modules,
     mock_find_impacted_files,
 ):
-    """When only dependency files changed, all tests should be returned (not None)."""
+    """When only dependency files changed, the strategy pipeline still runs.
+
+    Even though impacted_modules is empty (no .py files changed), the orchestrator
+    always delegates to strategies — DependencyFileImpactStrategy handles this case.
+    """
     mock_find_impacted_files.return_value = ["uv.lock"]
     mock_resolve_files_to_modules.return_value = []  # No .py files -> no modules
 
-    # Create a mock strategy that returns all test modules when dep files detected
     mock_strategy = MagicMock()
     mock_strategy.find_impacted_tests.return_value = ["test_module1", "test_module2"]
     mock_resolve_modules_to_files.return_value = ["test_file1.py", "test_file2.py"]
@@ -254,7 +257,6 @@ def test_get_impacted_tests_dep_file_only_change(
         watch_dep_files=True,
     )
 
-    # Should NOT return None — dep file change keeps the pipeline running
     assert result == ["test_file1.py", "test_file2.py"]
     mock_strategy.find_impacted_tests.assert_called_once()
 
@@ -265,7 +267,10 @@ def test_get_impacted_tests_dep_file_with_watch_disabled(
     mock_resolve_files_to_modules,
     mock_find_impacted_files,
 ):
-    """When watch_dep_files=False, dep-only changes should return None."""
+    """When watch_dep_files=False, DependencyFileImpactStrategy is excluded from the default
+    composite. With no .py modules changed, the remaining strategies (AST, Pytest) find
+    nothing, so the result is None.
+    """
     mock_find_impacted_files.return_value = ["uv.lock"]
     mock_resolve_files_to_modules.return_value = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,7 @@ class TestImpactedTestsCLI:
                 root_dir=".",
                 ns_module="test_ns",
                 tests_dir=None,
+                watch_dep_files=True,
             )
 
             # Check that the impacted tests are printed to stdout
@@ -122,6 +123,7 @@ class TestImpactedTestsCLI:
                 root_dir=".",
                 ns_module="test_ns",
                 tests_dir="tests",
+                watch_dep_files=True,
             )
 
     @patch("pytest_impacted.cli.get_impacted_tests")
@@ -268,6 +270,7 @@ class TestImpactedTestsCLI:
                 root_dir=".",  # default
                 ns_module="test_ns",
                 tests_dir=None,  # default
+                watch_dep_files=True,  # default
             )
 
     @patch("pytest_impacted.cli.get_impacted_tests")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -22,6 +22,7 @@ def cli_options():
         "impacted_git_mode",
         "impacted_base_branch",
         "impacted_tests_dir",
+        "no_impacted_dep_files",
     ]
 
 


### PR DESCRIPTION
## Summary

- **Dependency file change detection**: New `DependencyFileImpactStrategy` marks all tests as impacted when dependency files change (`uv.lock`, `requirements.txt`, `pyproject.toml`, `Pipfile.lock`, `poetry.lock`, `setup.py`, `setup.cfg`, `requirements/*.txt`). Opt-out via `--no-impacted-dep-files`
- **Strategy abstraction refactor**: Removed strategy-specific short-circuit logic from `api.py` — the orchestrator now always delegates to the strategy pipeline. Added `get_default_strategies()` factory to centralize default composition in `strategies.py`
- **Python 3.14 support**: Added to CI test matrix (both `ci.yml` and `ci-impacted.yml`) and PyPI classifiers

### Design

The orchestrator (`api.py`) has no strategy-specific logic — it always passes `changed_files` and `impacted_modules` (which may be empty) to the composite strategy, and each strategy decides what to do. This means strategies like `DependencyFileImpactStrategy` that operate on non-Python files work naturally without special-casing.

Default strategy composition is managed by `get_default_strategies()` in `strategies.py`. Adding a future strategy means editing one place.

## Test plan

- [x] 29 new tests across strategy, API, and factory function coverage
- [x] Full suite: 249 tests pass with coverage
- [x] Lint, format, type check all clean
- [x] All three documentation surfaces updated (CLAUDE.md, README.md, docs/usage.md)
- [x] Python 3.14 added to CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)