### PR TITLE
ci: bump astral-sh/setup-uv from v8.0.0 to v8.1.0

### DIFF
--- a/.github/workflows/ci-impacted.yml
+++ b/.github/workflows/ci-impacted.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.13"
         version: "latest"
@@ -44,7 +44,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.python-version }}
         version: "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.13"
         version: "latest"
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.python-version }}
         version: "latest"


### PR DESCRIPTION
## Summary

Routine version bump for `astral-sh/setup-uv` across both CI workflows (`ci.yml` and `ci-impacted.yml`). v8.1.0 adds an opt-in `no-project` input we don't use; otherwise no behavior change for our usage.

All other actions in this repo (`actions/checkout@v6`, `actions/setup-python@v6`, `actions/cache@v5`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `PyO3/maturin-action@v1`) are already at the current latest stable major. `pypa/gh-action-pypi-publish@release/v1` left as-is — that's the action's canonical moving release tag.

## Test plan

- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)