### PR TITLE
fix(security): require GitPython >= 3.1.58 and centralize git ref guarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ files, needs no special-casing. Keep it that way.
 keyword-only `dep_tree`. Caches: `cached_build_dep_tree` (maxsize=8) and
 `discover_submodules`; `clear_dep_tree_cache()` clears both.
 
+**Every revision passed to the git CLI goes through `git.rev_args()`** — never hand a ref
+straight to `repo.git.<cmd>(...)`. It validates each ref with `validate_rev` (rejecting
+option-like values with a clear error) *and* prefixes `--end-of-options` so git cannot parse
+an operand as an option even if the string check is ever bypassed. This is why the project
+requires git >= 2.24, and why tests assert on the `--end-of-options` token in the argv.
+
 **Logging: every module that logs declares `logger = logging.getLogger(__name__)`.**
 Never call `logging.info(...)` and friends — those hit the root logger and are
 flagged by LOG015.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For **37-65x faster** import parsing on large codebases, install with the option
 pip install pytest-impacted[fast]
 ```
 
-Requires **Python 3.11+**.
+Requires **Python 3.11+** and a **git 2.24+** CLI on `PATH`.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,11 @@
 # Usage Guide
 
+## Requirements
+
+Python 3.11+, and a **git 2.24+** CLI available on `PATH`. Revisions are passed to git
+after `--end-of-options` (added in git 2.24) so that a ref can never be parsed as a
+command-line option.
+
 ## Basic Usage
 
 Activate the plugin by passing the `--impacted` flag along with `--impacted-module` to pytest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,11 @@ classifiers = [
 dependencies = [
     "astroid>=4.1.2",
     "click>=8.2.0",
-    # >=3.1.52 excludes the command-injection / env-exfiltration advisories
-    # affecting GitPython <= 3.1.51 (GHSA CVE-2026-42215 and follow-ups).
-    "gitpython>=3.1.52",
+    # >=3.1.58 excludes the option-injection / arbitrary-file advisories affecting
+    # GitPython <= 3.1.57: GHSA-hmq2-w58f-27jc, GHSA-jm78-9fvv-mhgr,
+    # GHSA-wvpp-8hx9-p66j, GHSA-hh9p-6wh2-4mfc, GHSA-9rj7-rf2p-w77r,
+    # GHSA-4gmw-gg2m-w46p (and the earlier <= 3.1.51 injection advisories).
+    "gitpython>=3.1.58",
     "networkx>=3.4.2",
     "pytest>=8.0.0",
     "rich>=14.0.0",

--- a/pytest_impacted/git.py
+++ b/pytest_impacted/git.py
@@ -37,6 +37,29 @@ def validate_rev(rev: str) -> str:
     return rev
 
 
+#: Tells git that every following token is an operand, never an option.
+#: Supported by git >= 2.24.
+END_OF_OPTIONS = "--end-of-options"
+
+
+def rev_args(*revs: object) -> list[str]:
+    """Build the positional revision arguments for a ``git`` invocation.
+
+    Every revision handed to the git CLI must go through here, so that the
+    option-injection guard is applied uniformly rather than remembered at each
+    call site.  Revisions are stringified (callers may pass GitPython ``Commit``
+    or ``Reference`` objects), validated by :func:`validate_rev`, and prefixed
+    with :data:`END_OF_OPTIONS`.
+
+    The two guards are deliberately redundant: ``validate_rev`` rejects an
+    option-like value outright so the user gets a clear error instead of a
+    confusing git failure, while ``--end-of-options`` makes the guarantee
+    structural — git will not parse these tokens as options even if a value
+    ever slips past the string check.
+    """
+    return [END_OF_OPTIONS, *(validate_rev(str(rev)) for rev in revs)]
+
+
 class GitMode(StrEnum):
     """Git modes for the plugin."""
 
@@ -308,7 +331,7 @@ def impacted_files_for_branch_mode(repo: Repo, base_branch: str) -> list[str] | 
         # Detached HEAD state (common in CI) — fall back to HEAD commit
         current_ref = repo.head.commit
 
-    diffs = repo.git.diff(validate_rev(base_branch), current_ref, name_status=True)
+    diffs = repo.git.diff(*rev_args(base_branch, current_ref), name_status=True)
     change_set = ChangeSet.from_git_diff_name_status_output(diffs)
 
     impacted_files = []

--- a/pytest_impacted/plugin.py
+++ b/pytest_impacted/plugin.py
@@ -12,7 +12,7 @@ from pytest_impacted.extensions import (
     get_ext_cli_flag,
     get_ext_ini_name,
 )
-from pytest_impacted.git import GIT_AVAILABLE, GitMode, InvalidGitRefError, find_repo, validate_rev
+from pytest_impacted.git import GIT_AVAILABLE, GitMode, InvalidGitRefError, find_repo, rev_args
 
 
 def pytest_addoption(parser: Parser):
@@ -319,9 +319,9 @@ def validate_base_branch(base_branch: str, root_dir: str) -> None:
     from git import GitCommandError, InvalidGitRepositoryError  # noqa: PLC0415
 
     try:
-        validate_rev(base_branch)
+        args = rev_args(base_branch)
         repo = find_repo(root_dir)
-        repo.git.rev_parse("--verify", base_branch)
+        repo.git.rev_parse("--verify", *args)
     except InvalidGitRefError as err:
         raise UsageError(
             f"Invalid base branch: {err} Please check the value passed to --impacted-base-branch."

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -607,7 +607,7 @@ def test_impacted_files_for_branch_mode_detached_head(mock_repo):
 
     assert result == ["file1.py"]
     # Verify git.diff was called with the commit hash fallback
-    repo.git.diff.assert_called_once_with("main", "abc123", name_status=True)
+    repo.git.diff.assert_called_once_with("--end-of-options", "main", "abc123", name_status=True)
 
 
 # --- Tests for validate_rev (git option-injection guard) ---
@@ -633,6 +633,42 @@ def test_impacted_files_for_branch_mode_rejects_option_like_base_branch(mock_rep
 
     with pytest.raises(git.InvalidGitRefError):
         git.impacted_files_for_branch_mode(repo, "--output=/tmp/pwned")
+
+    repo.git.diff.assert_not_called()
+
+
+# --- Tests for rev_args (the shared revision-argument convention) ---
+
+
+def test_rev_args_prefixes_end_of_options():
+    """Revisions are passed as operands, so git cannot parse them as options."""
+    assert git.rev_args("main", "HEAD") == ["--end-of-options", "main", "HEAD"]
+
+
+def test_rev_args_stringifies_non_str_revisions():
+    """Callers may pass GitPython Commit/Reference objects rather than plain strings."""
+
+    class Commit:
+        def __str__(self):
+            return "abc123"
+
+    assert git.rev_args(Commit()) == ["--end-of-options", "abc123"]
+
+
+@pytest.mark.parametrize("rev", ["--upload-pack=touch /tmp/x", "-o"])
+def test_rev_args_rejects_option_like_revisions(rev):
+    """validate_rev is applied to every revision, not just the first."""
+    with pytest.raises(git.InvalidGitRefError):
+        git.rev_args("main", rev)
+
+
+def test_rev_args_validates_every_revision_including_the_current_ref():
+    """The second operand is guarded too — the guard is uniform, not per-call-site."""
+    repo = DummyRepo(diff_branch_result="M\tfile1.py\n")
+    repo.head.reference = "--output=/tmp/pwned"
+
+    with pytest.raises(git.InvalidGitRefError):
+        git.impacted_files_for_branch_mode(repo, "main")
 
     repo.git.diff.assert_not_called()
 

--- a/uv.lock
+++ b/uv.lock
@@ -207,14 +207,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ dev = [
 requires-dist = [
     { name = "astroid", specifier = ">=4.1.2" },
     { name = "click", specifier = ">=8.2.0" },
-    { name = "gitpython", specifier = ">=3.1.52" },
+    { name = "gitpython", specifier = ">=3.1.58" },
     { name = "networkx", specifier = ">=3.4.2" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-impacted-rs", marker = "extra == 'fast'", editable = "rust" },


### PR DESCRIPTION
## Summary

Closes the six open Dependabot alerts, all against **GitPython <= 3.1.57**, all fixed in **3.1.58**. Raises the floor to `>=3.1.58` and locks to **3.1.59**.

| Severity | Advisory | Vector |
|---|---|---|
| high | GHSA-hmq2-w58f-27jc | `.gitmodules` submodule name → repo creation outside the working tree |
| high | GHSA-jm78-9fvv-mhgr | `git-config` option-name injection → forged `core.sshCommand` / `hooksPath` (RCE) |
| high | GHSA-wvpp-8hx9-p66j | short-option token smuggling past the option guard |
| high | GHSA-9rj7-rf2p-w77r | `Repo.init --template` → clone-hook execution |
| high | GHSA-4gmw-gg2m-w46p | `read-tree` option forwarding → arbitrary file overwrite |
| medium | GHSA-hh9p-6wh2-4mfc | `--pathspec-from-file` in `IndexFile.remove()` / `Head.checkout()` → arbitrary file read |

## Reachability

**None of the six were reachable from this codebase.** We touch GitPython only through `Repo()`, `index.diff`, `untracked_files`, and two `repo.git.*` call sites. We never use submodules, `config_writer`, `Repo.init`, `IndexFile.from_tree/reset/merge_tree`, `remove()`, or `checkout()` — every vulnerable API is unused. This is hygiene, not incident response.

## Hardening

While verifying reachability, the option-injection guard added in #63 turned out to be applied *per call site* and unevenly: `base_branch` was validated, but `current_ref` in `impacted_files_for_branch_mode` was not. That operand is safe in practice (git forbids refs beginning with `-`), but "this one happens to be safe" is reasoning that decays as call sites are added.

Replaced with a single convention in `git.py` that every revision routes through:

```python
def rev_args(*revs: object) -> list[str]:
    return [END_OF_OPTIONS, *(validate_rev(str(rev)) for rev in revs)]
```

The two guards are deliberately redundant: `validate_rev` gives a clear error on a typo like `--main`, while `--end-of-options` makes the guarantee **structural** — git cannot parse an operand as an option even if the string check is ever bypassed. That turns the class of bug behind three of these advisories from "we check the string" into "git cannot misinterpret it".

## Compatibility

`--end-of-options` requires **git >= 2.24** (Nov 2019). Debian bullseye ships 2.30, RHEL 8 ships 2.43. Documented in the README requirements line.

## Tests

4 new tests in `tests/test_git.py`: the `--end-of-options` prefix, stringification of `Commit`/`Reference` objects, rejection at *any* operand position, and one that fails without this change (option-like `repo.head.reference` now raises instead of reaching the CLI). One existing assertion updated for the new argv shape.

348 tests pass; full `pre-commit run --all-files` gate clean. Both `GitMode.BRANCH` and `UNSTAGED` verified end-to-end against a real repo, since the diff call is mocked in unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb192jyZ37CedZxkRvnbF2