### PR TITLE
feat: user-defined invalidation patterns for non-Python files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,15 @@ and maturin (or `uv sync`) to build. Lint it from the repo root with
 `PytestImpactStrategy` (a changed `conftest.py` impacts every test in its directory
 and below — invisible to static import analysis), `DependencyFileImpactStrategy`
 (patterns in `DEFAULT_DEPENDENCY_FILE_PATTERNS` / `..._GLOB_PATTERNS`; disable with
-`--no-impacted-dep-files`), and `CompositeImpactStrategy`, which unions results.
-`get_default_strategies()` builds the default composition.
+`--no-impacted-dep-files`), `InvalidationFileImpactStrategy` (user globs from
+`--impacted-invalidate-all` / `--impacted-invalidate-dir`; only added to the pipeline when
+configured, and independent of `--no-impacted-dep-files`), and `CompositeImpactStrategy`,
+which unions results. `get_default_strategies()` builds the default composition.
+
+**All file globs go through `matches_any_glob`** (`PurePosixPath.match`, right-anchored,
+`*` never spans `/`), and the "tests in this directory and below" rule shared by the
+conftest logic and `--impacted-invalidate-dir` lives in `find_test_modules_under`. Do not
+add a second matcher or a second directory walk.
 
 Third-party strategies are discovered via the `pytest_impacted.strategies` entry
 point group and composed in by `extensions.build_strategy_with_extensions()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,14 +87,14 @@ and maturin (or `uv sync`) to build. Lint it from the repo root with
 and below — invisible to static import analysis), `DependencyFileImpactStrategy`
 (patterns in `DEFAULT_DEPENDENCY_FILE_PATTERNS` / `..._GLOB_PATTERNS`; disable with
 `--no-impacted-dep-files`), `InvalidationFileImpactStrategy` (user globs from
-`--impacted-invalidate-all` / `--impacted-invalidate-dir`; only added to the pipeline when
+`--impacted-invalidate-all`, marking every test impacted; only added to the pipeline when
 configured, and independent of `--no-impacted-dep-files`), and `CompositeImpactStrategy`,
 which unions results. `get_default_strategies()` builds the default composition.
 
 **All file globs go through `matches_any_glob`** (`PurePosixPath.match`, right-anchored,
-`*` never spans `/`), and the "tests in this directory and below" rule shared by the
-conftest logic and `--impacted-invalidate-dir` lives in `find_test_modules_under`. Do not
-add a second matcher or a second directory walk.
+`*` never spans `/`, and `**` is *not* recursive — it behaves like a single `*`), and the
+"tests in this directory and below" conftest rule lives in `find_test_modules_under`. Do
+not add a second matcher or a second directory walk.
 
 Third-party strategies are discovered via the `pytest_impacted.strategies` entry
 point group and composed in by `extensions.build_strategy_with_extensions()`.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pytest --impacted --impacted-module=my_package \
 | :test_tube: | **pytest-native** | Works as a standard pytest plugin with familiar CLI options |
 | :wrench: | **conftest.py aware** | Changes to `conftest.py` automatically impact all tests in scope |
 | :package: | **Dependency-file aware** | Changes to `uv.lock`, `requirements.txt`, `pyproject.toml` etc. trigger all tests |
+| :dart: | **Custom invalidation rules** | Declare your own globs (`*.json`, `fixtures/*.sql`, …) that trigger all tests, or the tests in the same directory |
 | :building_construction: | **CI-friendly** | Standalone `impacted-tests` CLI for two-stage CI pipelines |
 | :rocket: | **Rust-accelerated** | Optional Rust extension for 37-65x faster import parsing on large codebases |
 | :electric_plug: | **Extensible** | Third-party strategies installable as plugins via Python entry points |
@@ -136,7 +137,7 @@ pytest $(cat impacted_tests.txt)
 ```
 
 The CLI accepts `--module`, `--git-mode`, `--base-branch`, `--root-dir`, `--tests-dir`,
-`--verbose`, `--no-dep-files` and `--disable-ext`. If your tests live outside the package,
+`--verbose`, `--no-dep-files`, `--invalidate-all`, `--invalidate-dir` and `--disable-ext`. If your tests live outside the package,
 pass `--tests-dir` here as well — see the [usage guide](https://promptromp.github.io/pytest-impacted/usage/#impacted-tests-options).
 
 ### Configuration via `pyproject.toml`
@@ -151,6 +152,8 @@ impacted_git_mode = "branch"
 impacted_base_branch = "main"
 impacted_tests_dir = "tests"
 # no_impacted_dep_files = true  # uncomment to disable dep file detection
+# impacted_invalidate_all = ["*.json"]      # non-Python files that should trigger every test
+# impacted_invalidate_dir = ["fixtures/*"]  # ... or only the tests in the same directory and below
 ```
 
 CLI flags override these defaults.
@@ -165,6 +168,8 @@ CLI flags override these defaults.
 | `--impacted-base-branch` | *(required for branch mode)* | Base branch/ref for branch-mode comparison |
 | `--impacted-tests-dir` | `None` | Directory containing tests outside the package |
 | `--no-impacted-dep-files` | `false` | Disable dependency file change detection |
+| `--impacted-invalidate-all` | `[]` | Glob for files that, when changed, mark **all** tests as impacted (repeatable) |
+| `--impacted-invalidate-dir` | `[]` | Glob for files that, when changed, mark tests in the **same directory and below** as impacted (repeatable) |
 | `--impacted-disable-ext` | `[]` | Disable a strategy extension by name (repeatable) |
 
 ---
@@ -174,6 +179,7 @@ CLI flags override these defaults.
 ```
 Git diff → Changed files → Module resolution → AST import parsing → Dependency graph → Impacted tests
                          ↘ Dependency file detection → All tests (if dep files changed)
+                         ↘ Invalidation patterns → All tests / tests in the same directory (if configured)
 ```
 
 1. **Git introspection** identifies which files changed (unstaged edits or branch diff)
@@ -181,19 +187,21 @@ Git diff → Changed files → Module resolution → AST import parsing → Depe
 3. **AST parsing** (via [astroid](https://pylint.pycqa.org/projects/astroid/en/latest/), or the optional Rust extension using [ruff's parser](https://github.com/astral-sh/ruff)) extracts import relationships from source files
 4. **Dependency graph** (via [NetworkX](https://networkx.org/)) traces transitive dependencies from changed modules to test modules
 5. **Dependency file detection** — if files like `uv.lock`, `requirements.txt`, or `pyproject.toml` changed, all tests are marked as impacted regardless of import analysis
-6. **Test filtering** skips tests whose modules are not in the impact set
+6. **Invalidation patterns** — user-declared globs for non-Python files (JSON fixtures, SQL schemas, YAML configs, …) that static analysis cannot see; see `--impacted-invalidate-all` / `--impacted-invalidate-dir`
+7. **Test filtering** skips tests whose modules are not in the impact set
 
 The philosophy is to **err on the side of caution**: we favor false positives (running a test that didn't need to run) over false negatives (missing a test that should have run).
 
 ### Strategy-Based Architecture
 
-Impact analysis is pluggable via a strategy pattern. The default pipeline combines three strategies:
+Impact analysis is pluggable via a strategy pattern. The default pipeline combines these built-in strategies:
 
 | Strategy | What it does |
 |----------|-------------|
 | **ASTImpactStrategy** | Traces transitive import dependencies through the dependency graph |
 | **PytestImpactStrategy** | Extends AST analysis with pytest-specific knowledge — when a `conftest.py` file changes, **all tests in its directory and subdirectories** are marked as impacted |
 | **DependencyFileImpactStrategy** | When dependency files change (`uv.lock`, `requirements.txt`, `pyproject.toml`, etc.), **all tests** are marked as impacted |
+| **InvalidationFileImpactStrategy** | Only active when configured. Files matching `--impacted-invalidate-all` mark **all tests** as impacted; files matching `--impacted-invalidate-dir` mark the tests in the **same directory and below** as impacted |
 
 All strategies are combined via `CompositeImpactStrategy`, which deduplicates and merges their results. Dependency file detection is enabled by default and can be disabled with `--no-impacted-dep-files`.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ pytest $(cat impacted_tests.txt)
 ```
 
 The CLI accepts `--module`, `--git-mode`, `--base-branch`, `--root-dir`, `--tests-dir`,
-`--verbose`, `--no-dep-files`, `--invalidate-all`, `--invalidate-dir` and `--disable-ext`. If your tests live outside the package,
+`--verbose`, `--no-dep-files`, `--invalidate-all` and `--disable-ext`. If your tests live outside the package,
 pass `--tests-dir` here as well — see the [usage guide](https://promptromp.github.io/pytest-impacted/usage/#impacted-tests-options).
 
 ### Configuration via `pyproject.toml`
@@ -152,8 +152,7 @@ impacted_git_mode = "branch"
 impacted_base_branch = "main"
 impacted_tests_dir = "tests"
 # no_impacted_dep_files = true  # uncomment to disable dep file detection
-# impacted_invalidate_all = ["*.json"]      # non-Python files that should trigger every test
-# impacted_invalidate_dir = ["fixtures/*"]  # ... or only the tests in the same directory and below
+# impacted_invalidate_all = ["*.json"]  # non-Python files that should trigger every test
 ```
 
 CLI flags override these defaults.
@@ -169,7 +168,6 @@ CLI flags override these defaults.
 | `--impacted-tests-dir` | `None` | Directory containing tests outside the package |
 | `--no-impacted-dep-files` | `false` | Disable dependency file change detection |
 | `--impacted-invalidate-all` | `[]` | Glob for files that, when changed, mark **all** tests as impacted (repeatable) |
-| `--impacted-invalidate-dir` | `[]` | Glob for files that, when changed, mark tests in the **same directory and below** as impacted (repeatable) |
 | `--impacted-disable-ext` | `[]` | Disable a strategy extension by name (repeatable) |
 
 ---
@@ -187,7 +185,7 @@ Git diff → Changed files → Module resolution → AST import parsing → Depe
 3. **AST parsing** (via [astroid](https://pylint.pycqa.org/projects/astroid/en/latest/), or the optional Rust extension using [ruff's parser](https://github.com/astral-sh/ruff)) extracts import relationships from source files
 4. **Dependency graph** (via [NetworkX](https://networkx.org/)) traces transitive dependencies from changed modules to test modules
 5. **Dependency file detection** — if files like `uv.lock`, `requirements.txt`, or `pyproject.toml` changed, all tests are marked as impacted regardless of import analysis
-6. **Invalidation patterns** — user-declared globs for non-Python files (JSON fixtures, SQL schemas, YAML configs, …) that static analysis cannot see; see `--impacted-invalidate-all` / `--impacted-invalidate-dir`
+6. **Invalidation patterns** — user-declared globs for non-Python files (JSON fixtures, SQL schemas, YAML configs, …) that static analysis cannot see; see `--impacted-invalidate-all`
 7. **Test filtering** skips tests whose modules are not in the impact set
 
 The philosophy is to **err on the side of caution**: we favor false positives (running a test that didn't need to run) over false negatives (missing a test that should have run).
@@ -201,7 +199,7 @@ Impact analysis is pluggable via a strategy pattern. The default pipeline combin
 | **ASTImpactStrategy** | Traces transitive import dependencies through the dependency graph |
 | **PytestImpactStrategy** | Extends AST analysis with pytest-specific knowledge — when a `conftest.py` file changes, **all tests in its directory and subdirectories** are marked as impacted |
 | **DependencyFileImpactStrategy** | When dependency files change (`uv.lock`, `requirements.txt`, `pyproject.toml`, etc.), **all tests** are marked as impacted |
-| **InvalidationFileImpactStrategy** | Only active when configured. Files matching `--impacted-invalidate-all` mark **all tests** as impacted; files matching `--impacted-invalidate-dir` mark the tests in the **same directory and below** as impacted |
+| **InvalidationFileImpactStrategy** | Only active when configured. Files matching a `--impacted-invalidate-all` glob mark **all tests** as impacted — the user-extensible counterpart to the built-in dependency-file list |
 
 All strategies are combined via `CompositeImpactStrategy`, which deduplicates and merges their results. Dependency file detection is enabled by default and can be disabled with `--no-impacted-dep-files`.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pytest --impacted --impacted-module=my_package \
 | :test_tube: | **pytest-native** | Works as a standard pytest plugin with familiar CLI options |
 | :wrench: | **conftest.py aware** | Changes to `conftest.py` automatically impact all tests in scope |
 | :package: | **Dependency-file aware** | Changes to `uv.lock`, `requirements.txt`, `pyproject.toml` etc. trigger all tests |
-| :dart: | **Custom invalidation rules** | Declare your own globs (`*.json`, `fixtures/*.sql`, …) that trigger all tests, or the tests in the same directory |
+| :dart: | **Custom invalidation rules** | Declare your own globs (`*.json`, `config/*.yaml`, …) that trigger all tests |
 | :building_construction: | **CI-friendly** | Standalone `impacted-tests` CLI for two-stage CI pipelines |
 | :rocket: | **Rust-accelerated** | Optional Rust extension for 37-65x faster import parsing on large codebases |
 | :electric_plug: | **Extensible** | Third-party strategies installable as plugins via Python entry points |
@@ -177,7 +177,7 @@ CLI flags override these defaults.
 ```
 Git diff → Changed files → Module resolution → AST import parsing → Dependency graph → Impacted tests
                          ↘ Dependency file detection → All tests (if dep files changed)
-                         ↘ Invalidation patterns → All tests / tests in the same directory (if configured)
+                         ↘ Invalidation patterns → All tests (if your globs match)
 ```
 
 1. **Git introspection** identifies which files changed (unstaged edits or branch diff)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,7 +97,7 @@ Run pytest from the `backend/` directory as usual. The plugin will:
 
 ## Impact Analysis Strategies
 
-The plugin uses a modular, strategy-based architecture to determine which tests are affected by code changes. Strategies are composable — the default pipeline combines three built-in strategies.
+The plugin uses a modular, strategy-based architecture to determine which tests are affected by code changes. Strategies are composable — the default pipeline combines the built-in strategies below (the last one only when configured).
 
 ### ASTImpactStrategy
 
@@ -135,6 +135,43 @@ pytest --impacted --impacted-module=my_package --no-impacted-dep-files
 !!! tip
     This is especially useful in CI where dependency version bumps (e.g. updating `uv.lock`) don't change any `.py` files but could still break tests due to changed third-party behavior.
 
+### InvalidationFileImpactStrategy
+
+Static import analysis cannot see that a test depends on a JSON fixture, a SQL schema, or a YAML config. This strategy lets you declare those relationships yourself with glob patterns. It is only added to the pipeline when at least one pattern is configured.
+
+Two kinds of pattern are supported, and both options are repeatable:
+
+| Option | Effect when a changed file matches |
+|--------|------------------------------------|
+| `--impacted-invalidate-all PATTERN` | **All** tests are marked as impacted — the same effect as a `pyproject.toml` change |
+| `--impacted-invalidate-dir PATTERN` | Tests in the changed file's **directory and all subdirectories** are marked as impacted — the same effect as a `conftest.py` change |
+
+```bash
+# Any .json change anywhere runs the whole suite; a changed SQL file under
+# tests/integration/ only runs the tests under tests/integration/
+pytest --impacted --impacted-module=my_package --impacted-tests-dir=tests \
+    --impacted-invalidate-all='*.json' \
+    --impacted-invalidate-dir='*.sql'
+```
+
+Or in `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+impacted_invalidate_all = ["*.json", "config/*.yaml"]
+impacted_invalidate_dir = ["*.sql", "fixtures/*"]
+```
+
+Patterns are matched against the repository-relative path of each changed file, anchored at the end of the path (Python's `PurePath.match` semantics):
+
+- `*.json` matches a JSON file at any depth
+- `config/*.json` matches JSON files directly inside any directory named `config`
+- `schema.graphql` matches that filename anywhere
+- `*` never spans a `/`, so `fixtures/*.sql` does not match `fixtures/sub/x.sql`
+
+!!! note
+    This is independent of `--no-impacted-dep-files`, which only switches off the built-in dependency-file list. Custom invalidation patterns stay active either way.
+
 ### CompositeImpactStrategy
 
 Combines multiple strategies, deduplicating and sorting results. The default composition is:
@@ -145,6 +182,8 @@ CompositeImpactStrategy(
         ASTImpactStrategy(),
         PytestImpactStrategy(),
         DependencyFileImpactStrategy(),
+        # Only present when --impacted-invalidate-all / --impacted-invalidate-dir are set
+        InvalidationFileImpactStrategy(all_patterns=[...], dir_patterns=[...]),
     ]
 )
 ```
@@ -186,6 +225,8 @@ impacted-tests --module=my_package --tests-dir=tests --git-mode=branch --base-br
 | `--tests-dir` | `None` | Directory containing test files outside the namespace module |
 | `--verbose` | `false` | Verbose output (written to stderr, so it will not pollute the piped test list) |
 | `--no-dep-files` | `false` | Disable dependency file change detection |
+| `--invalidate-all` | `[]` | Glob for files that, when changed, mark all tests as impacted (repeatable) |
+| `--invalidate-dir` | `[]` | Glob for files that, when changed, mark tests in the same directory and below as impacted (repeatable) |
 | `--disable-ext` | `[]` | Disable a strategy extension by name (repeatable) |
 
 ## Configuration via `pyproject.toml`
@@ -200,6 +241,8 @@ impacted_git_mode = "branch"
 impacted_base_branch = "main"
 impacted_tests_dir = "tests"
 no_impacted_dep_files = false  # set to true to disable dep file detection
+impacted_invalidate_all = ["*.json"]      # non-Python files that should trigger every test
+impacted_invalidate_dir = ["fixtures/*"]  # ... or only the tests in the same directory and below
 ```
 
 CLI flags override these defaults.
@@ -228,6 +271,8 @@ The plugin validates configuration early and provides helpful error messages:
 | `--impacted-base-branch` | *(required for branch mode)* | Base branch/ref for branch-mode comparison |
 | `--impacted-tests-dir` | `None` | Directory containing tests outside the package |
 | `--no-impacted-dep-files` | `false` | Disable dependency file change detection |
+| `--impacted-invalidate-all` | `[]` | Glob for files that, when changed, mark all tests as impacted (repeatable) |
+| `--impacted-invalidate-dir` | `[]` | Glob for files that, when changed, mark tests in the same directory and below as impacted (repeatable) |
 | `--impacted-disable-ext` | `[]` | Disable a strategy extension by name (repeatable) |
 | `--impacted-ext-{ext}-{option}` | *(per extension)* | Set a config option on an installed extension. Installed extensions register their own flags — run `pytest --help` to list them, or see the [Extensions guide](extensions.md#extension-with-configuration) |
 
@@ -242,6 +287,8 @@ graph LR
     E --> G[Impacted tests]
     B --> F[Dep file detection]
     F -->|uv.lock, requirements.txt, etc.| G
+    B --> H[Invalidation patterns]
+    H -->|--impacted-invalidate-all / -dir| G
 ```
 
 1. **Git introspection** identifies which files changed (unstaged edits or branch diff)
@@ -249,7 +296,8 @@ graph LR
 3. **AST parsing** (via [astroid](https://pylint.pycqa.org/projects/astroid/en/latest/), or the optional Rust extension using [ruff's hand-written recursive descent parser](https://github.com/astral-sh/ruff)) extracts import relationships from source files
 4. **Dependency graph** (via [NetworkX](https://networkx.org/)) traces transitive dependencies from changed modules to test modules
 5. **Dependency file detection** — if files like `uv.lock`, `requirements.txt`, or `pyproject.toml` changed, all tests are marked as impacted regardless of import analysis
-6. **Test filtering** skips tests whose modules are not in the impact set
+6. **Invalidation patterns** — user-declared globs for non-Python files that static analysis cannot see (see [InvalidationFileImpactStrategy](#invalidationfileimpactstrategy))
+7. **Test filtering** skips tests whose modules are not in the impact set
 
 The philosophy is to **err on the side of caution**: false positives (running a test that didn't need to run) are preferred over false negatives (missing a test that should have run).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -137,29 +137,21 @@ pytest --impacted --impacted-module=my_package --no-impacted-dep-files
 
 ### InvalidationFileImpactStrategy
 
-Static import analysis cannot see that a test depends on a JSON fixture, a SQL schema, or a YAML config. This strategy lets you declare those relationships yourself with glob patterns. It is only added to the pipeline when at least one pattern is configured.
+Static import analysis cannot see that a test depends on a JSON fixture, a SQL schema, or a YAML config. This strategy is the user-extensible counterpart to the built-in dependency-file list: any changed file matching one of your `--impacted-invalidate-all` globs marks **all** tests as impacted, exactly as a `pyproject.toml` change does. It is only added to the pipeline when at least one pattern is configured.
 
-Two kinds of pattern are supported, and both options are repeatable:
-
-| Option | Effect when a changed file matches |
-|--------|------------------------------------|
-| `--impacted-invalidate-all PATTERN` | **All** tests are marked as impacted — the same effect as a `pyproject.toml` change |
-| `--impacted-invalidate-dir PATTERN` | Tests in the changed file's **directory and all subdirectories** are marked as impacted — the same effect as a `conftest.py` change |
+The option is repeatable:
 
 ```bash
-# Any .json change anywhere runs the whole suite; a changed SQL file under
-# tests/integration/ only runs the tests under tests/integration/
 pytest --impacted --impacted-module=my_package --impacted-tests-dir=tests \
     --impacted-invalidate-all='*.json' \
-    --impacted-invalidate-dir='*.sql'
+    --impacted-invalidate-all='my_package/config/*.yaml'
 ```
 
 Or in `pyproject.toml`:
 
 ```toml
 [tool.pytest.ini_options]
-impacted_invalidate_all = ["*.json", "config/*.yaml"]
-impacted_invalidate_dir = ["*.sql", "fixtures/*"]
+impacted_invalidate_all = ["*.json", "my_package/config/*.yaml"]
 ```
 
 Patterns are matched against the repository-relative path of each changed file, anchored at the end of the path (Python's `PurePath.match` semantics):
@@ -168,6 +160,7 @@ Patterns are matched against the repository-relative path of each changed file, 
 - `config/*.json` matches JSON files directly inside any directory named `config`
 - `schema.graphql` matches that filename anywhere
 - `*` never spans a `/`, so `fixtures/*.sql` does not match `fixtures/sub/x.sql`
+- `**` is **not** recursive here — it behaves like a single `*`. To watch a directory tree, list a pattern per depth: `config/*`, `config/*/*`, …
 
 !!! note
     This is independent of `--no-impacted-dep-files`, which only switches off the built-in dependency-file list. Custom invalidation patterns stay active either way.
@@ -182,8 +175,8 @@ CompositeImpactStrategy(
         ASTImpactStrategy(),
         PytestImpactStrategy(),
         DependencyFileImpactStrategy(),
-        # Only present when --impacted-invalidate-all / --impacted-invalidate-dir are set
-        InvalidationFileImpactStrategy(all_patterns=[...], dir_patterns=[...]),
+        # Only present when --impacted-invalidate-all is set
+        InvalidationFileImpactStrategy([...]),
     ]
 )
 ```
@@ -226,7 +219,6 @@ impacted-tests --module=my_package --tests-dir=tests --git-mode=branch --base-br
 | `--verbose` | `false` | Verbose output (written to stderr, so it will not pollute the piped test list) |
 | `--no-dep-files` | `false` | Disable dependency file change detection |
 | `--invalidate-all` | `[]` | Glob for files that, when changed, mark all tests as impacted (repeatable) |
-| `--invalidate-dir` | `[]` | Glob for files that, when changed, mark tests in the same directory and below as impacted (repeatable) |
 | `--disable-ext` | `[]` | Disable a strategy extension by name (repeatable) |
 
 ## Configuration via `pyproject.toml`
@@ -241,8 +233,7 @@ impacted_git_mode = "branch"
 impacted_base_branch = "main"
 impacted_tests_dir = "tests"
 no_impacted_dep_files = false  # set to true to disable dep file detection
-impacted_invalidate_all = ["*.json"]      # non-Python files that should trigger every test
-impacted_invalidate_dir = ["fixtures/*"]  # ... or only the tests in the same directory and below
+impacted_invalidate_all = ["*.json"]  # non-Python files that should trigger every test
 ```
 
 CLI flags override these defaults.
@@ -272,7 +263,6 @@ The plugin validates configuration early and provides helpful error messages:
 | `--impacted-tests-dir` | `None` | Directory containing tests outside the package |
 | `--no-impacted-dep-files` | `false` | Disable dependency file change detection |
 | `--impacted-invalidate-all` | `[]` | Glob for files that, when changed, mark all tests as impacted (repeatable) |
-| `--impacted-invalidate-dir` | `[]` | Glob for files that, when changed, mark tests in the same directory and below as impacted (repeatable) |
 | `--impacted-disable-ext` | `[]` | Disable a strategy extension by name (repeatable) |
 | `--impacted-ext-{ext}-{option}` | *(per extension)* | Set a config option on an installed extension. Installed extensions register their own flags — run `pytest --help` to list them, or see the [Extensions guide](extensions.md#extension-with-configuration) |
 
@@ -288,7 +278,7 @@ graph LR
     B --> F[Dep file detection]
     F -->|uv.lock, requirements.txt, etc.| G
     B --> H[Invalidation patterns]
-    H -->|--impacted-invalidate-all / -dir| G
+    H -->|--impacted-invalidate-all| G
 ```
 
 1. **Git introspection** identifies which files changed (unstaged edits or branch diff)

--- a/pytest_impacted/api.py
+++ b/pytest_impacted/api.py
@@ -34,13 +34,11 @@ def get_impacted_tests(
     strategy: ImpactStrategy | None = None,
     watch_dep_files: bool = True,
     invalidate_all_patterns: Sequence[str] = (),
-    invalidate_dir_patterns: Sequence[str] = (),
 ) -> list[str] | None:
     """Get the list of impacted tests based on the git state and static analysis.
 
-    ``watch_dep_files``, ``invalidate_all_patterns`` and ``invalidate_dir_patterns``
-    configure the default pipeline and are ignored when an explicit ``strategy``
-    is supplied.
+    ``watch_dep_files`` and ``invalidate_all_patterns`` configure the default
+    pipeline and are ignored when an explicit ``strategy`` is supplied.
     """
     git_mode = impacted_git_mode
     base_branch = impacted_base_branch
@@ -51,7 +49,6 @@ def get_impacted_tests(
             get_default_strategies(
                 watch_dep_files=watch_dep_files,
                 invalidate_all_patterns=invalidate_all_patterns,
-                invalidate_dir_patterns=invalidate_dir_patterns,
             )
         )
 

--- a/pytest_impacted/api.py
+++ b/pytest_impacted/api.py
@@ -1,6 +1,7 @@
 """Matchers used for pattern matching and unit-tests."""
 
 import os
+from collections.abc import Sequence
 from pathlib import Path
 
 from pytest_impacted.display import notify, warn
@@ -32,14 +33,27 @@ def get_impacted_tests(
     session=None,
     strategy: ImpactStrategy | None = None,
     watch_dep_files: bool = True,
+    invalidate_all_patterns: Sequence[str] = (),
+    invalidate_dir_patterns: Sequence[str] = (),
 ) -> list[str] | None:
-    """Get the list of impacted tests based on the git state and static analysis."""
+    """Get the list of impacted tests based on the git state and static analysis.
+
+    ``watch_dep_files``, ``invalidate_all_patterns`` and ``invalidate_dir_patterns``
+    configure the default pipeline and are ignored when an explicit ``strategy``
+    is supplied.
+    """
     git_mode = impacted_git_mode
     base_branch = impacted_base_branch
 
     # Use default strategy if none provided
     if strategy is None:
-        strategy = CompositeImpactStrategy(get_default_strategies(watch_dep_files=watch_dep_files))
+        strategy = CompositeImpactStrategy(
+            get_default_strategies(
+                watch_dep_files=watch_dep_files,
+                invalidate_all_patterns=invalidate_all_patterns,
+                invalidate_dir_patterns=invalidate_dir_patterns,
+            )
+        )
 
     tests_package = None
     if tests_dir:

--- a/pytest_impacted/cli.py
+++ b/pytest_impacted/cli.py
@@ -61,10 +61,35 @@ def configure_logging(verbose: bool) -> None:
 )
 @click.option("--verbose", is_flag=True, help="Verbose output.")
 @click.option("--no-dep-files", is_flag=True, default=False, help="Disable dependency file change detection.")
+@click.option(
+    "--invalidate-all",
+    multiple=True,
+    default=(),
+    metavar="PATTERN",
+    help="Glob for files that, when changed, mark ALL tests as impacted (repeatable).",
+)
+@click.option(
+    "--invalidate-dir",
+    multiple=True,
+    default=(),
+    metavar="PATTERN",
+    help="Glob for files that, when changed, mark tests in the same directory and below as impacted (repeatable).",
+)
 @click.option("--disable-ext", multiple=True, default=(), help="Disable a strategy extension by name (repeatable).")
 @click.pass_context
 def impacted_tests_cli(
-    ctx, git_mode, base_branch, root_dir, module, tests_dir, verbose, no_dep_files, disable_ext, **ext_kwargs
+    ctx,
+    git_mode,
+    base_branch,
+    root_dir,
+    module,
+    tests_dir,
+    verbose,
+    no_dep_files,
+    invalidate_all,
+    invalidate_dir,
+    disable_ext,
+    **ext_kwargs,
 ):
     """CLI entrypoint for impacted-tests console script."""
     click.echo("impacted-tests", err=True)
@@ -74,6 +99,10 @@ def impacted_tests_cli(
     click.secho(f"  root-dir: {root_dir}", fg="blue", bold=True, err=True)
     click.secho(f"  tests-dir: {tests_dir}", fg="blue", bold=True, err=True)
     click.secho(f"  no-dep-files: {no_dep_files}", fg="blue", bold=True, err=True)
+    if invalidate_all:
+        click.secho("  invalidate-all: {}".format(", ".join(invalidate_all)), fg="blue", bold=True, err=True)
+    if invalidate_dir:
+        click.secho("  invalidate-dir: {}".format(", ".join(invalidate_dir)), fg="blue", bold=True, err=True)
     if disable_ext:
         click.secho("  disable-ext: {}".format(", ".join(disable_ext)), fg="blue", bold=True, err=True)
 
@@ -81,6 +110,8 @@ def impacted_tests_cli(
 
     strategy = build_strategy_with_extensions(
         watch_dep_files=not no_dep_files,
+        invalidate_all_patterns=invalidate_all,
+        invalidate_dir_patterns=invalidate_dir,
         disabled=disable_ext,
         ext_config=ext_kwargs,
     )

--- a/pytest_impacted/cli.py
+++ b/pytest_impacted/cli.py
@@ -68,13 +68,6 @@ def configure_logging(verbose: bool) -> None:
     metavar="PATTERN",
     help="Glob for files that, when changed, mark ALL tests as impacted (repeatable).",
 )
-@click.option(
-    "--invalidate-dir",
-    multiple=True,
-    default=(),
-    metavar="PATTERN",
-    help="Glob for files that, when changed, mark tests in the same directory and below as impacted (repeatable).",
-)
 @click.option("--disable-ext", multiple=True, default=(), help="Disable a strategy extension by name (repeatable).")
 @click.pass_context
 def impacted_tests_cli(
@@ -87,7 +80,6 @@ def impacted_tests_cli(
     verbose,
     no_dep_files,
     invalidate_all,
-    invalidate_dir,
     disable_ext,
     **ext_kwargs,
 ):
@@ -101,8 +93,6 @@ def impacted_tests_cli(
     click.secho(f"  no-dep-files: {no_dep_files}", fg="blue", bold=True, err=True)
     if invalidate_all:
         click.secho("  invalidate-all: {}".format(", ".join(invalidate_all)), fg="blue", bold=True, err=True)
-    if invalidate_dir:
-        click.secho("  invalidate-dir: {}".format(", ".join(invalidate_dir)), fg="blue", bold=True, err=True)
     if disable_ext:
         click.secho("  disable-ext: {}".format(", ".join(disable_ext)), fg="blue", bold=True, err=True)
 
@@ -111,7 +101,6 @@ def impacted_tests_cli(
     strategy = build_strategy_with_extensions(
         watch_dep_files=not no_dep_files,
         invalidate_all_patterns=invalidate_all,
-        invalidate_dir_patterns=invalidate_dir,
         disabled=disable_ext,
         ext_config=ext_kwargs,
     )

--- a/pytest_impacted/extensions.py
+++ b/pytest_impacted/extensions.py
@@ -306,6 +306,8 @@ def load_extensions(
 def build_strategy_with_extensions(
     *,
     watch_dep_files: bool = True,
+    invalidate_all_patterns: Sequence[str] = (),
+    invalidate_dir_patterns: Sequence[str] = (),
     disabled: Sequence[str] = (),
     ext_config: dict[str, Any] | None = None,
 ) -> ImpactStrategy:
@@ -316,6 +318,10 @@ def build_strategy_with_extensions(
 
     Args:
         watch_dep_files: Whether to include DependencyFileImpactStrategy.
+        invalidate_all_patterns: User globs whose matches impact every test
+            (see :class:`~pytest_impacted.strategies.InvalidationFileImpactStrategy`).
+        invalidate_dir_patterns: User globs whose matches impact tests in the
+            changed file's directory and below.
         disabled: Extension names to exclude.
         ext_config: Configuration values for extensions.
 
@@ -324,7 +330,11 @@ def build_strategy_with_extensions(
     """
     from pytest_impacted.strategies import CompositeImpactStrategy, get_default_strategies  # noqa: PLC0415
 
-    builtin_strategies = get_default_strategies(watch_dep_files=watch_dep_files)
+    builtin_strategies = get_default_strategies(
+        watch_dep_files=watch_dep_files,
+        invalidate_all_patterns=invalidate_all_patterns,
+        invalidate_dir_patterns=invalidate_dir_patterns,
+    )
     ext_strategies = load_extensions(disabled=disabled, ext_config=ext_config)
 
     # Sort extensions by priority (built-ins keep their fixed order)

--- a/pytest_impacted/extensions.py
+++ b/pytest_impacted/extensions.py
@@ -307,7 +307,6 @@ def build_strategy_with_extensions(
     *,
     watch_dep_files: bool = True,
     invalidate_all_patterns: Sequence[str] = (),
-    invalidate_dir_patterns: Sequence[str] = (),
     disabled: Sequence[str] = (),
     ext_config: dict[str, Any] | None = None,
 ) -> ImpactStrategy:
@@ -320,8 +319,6 @@ def build_strategy_with_extensions(
         watch_dep_files: Whether to include DependencyFileImpactStrategy.
         invalidate_all_patterns: User globs whose matches impact every test
             (see :class:`~pytest_impacted.strategies.InvalidationFileImpactStrategy`).
-        invalidate_dir_patterns: User globs whose matches impact tests in the
-            changed file's directory and below.
         disabled: Extension names to exclude.
         ext_config: Configuration values for extensions.
 
@@ -333,7 +330,6 @@ def build_strategy_with_extensions(
     builtin_strategies = get_default_strategies(
         watch_dep_files=watch_dep_files,
         invalidate_all_patterns=invalidate_all_patterns,
-        invalidate_dir_patterns=invalidate_dir_patterns,
     )
     ext_strategies = load_extensions(disabled=disabled, ext_config=ext_config)
 

--- a/pytest_impacted/plugin.py
+++ b/pytest_impacted/plugin.py
@@ -105,6 +105,42 @@ def pytest_addoption(parser: Parser):
         default=False,
     )
 
+    group.addoption(
+        "--impacted-invalidate-all",
+        action="append",
+        default=[],
+        dest="impacted_invalidate_all",
+        metavar="PATTERN",
+        help=(
+            "Glob pattern for files that, when changed, mark ALL tests as impacted "
+            "(e.g. '*.json', 'config/*.yaml'). Repeatable."
+        ),
+    )
+    parser.addini(
+        "impacted_invalidate_all",
+        help="default value for --impacted-invalidate-all (list of glob patterns)",
+        type="args",
+        default=[],
+    )
+
+    group.addoption(
+        "--impacted-invalidate-dir",
+        action="append",
+        default=[],
+        dest="impacted_invalidate_dir",
+        metavar="PATTERN",
+        help=(
+            "Glob pattern for files that, when changed, mark tests in the same directory "
+            "and below as impacted (like conftest.py). Repeatable."
+        ),
+    )
+    parser.addini(
+        "impacted_invalidate_dir",
+        help="default value for --impacted-invalidate-dir (list of glob patterns)",
+        type="args",
+        default=[],
+    )
+
     # Extension management
     group.addoption(
         "--impacted-disable-ext",
@@ -165,6 +201,8 @@ def pytest_report_header(config: Config) -> list[str]:
         f"impacted_base_branch={get_option('impacted_base_branch')}",
         f"impacted_tests_dir={get_option('impacted_tests_dir')}",
         f"no_impacted_dep_files={get_option('no_impacted_dep_files')}",
+        f"impacted_invalidate_all={get_option('impacted_invalidate_all')}",
+        f"impacted_invalidate_dir={get_option('impacted_invalidate_dir')}",
         f"backend={backend}",
     ]
     if ext_names:
@@ -191,12 +229,16 @@ def pytest_collection_modifyitems(session, config, items):
     impacted_base_branch = get_option("impacted_base_branch")
     impacted_tests_dir = get_option("impacted_tests_dir")
     no_dep_files = get_option("no_impacted_dep_files")
+    invalidate_all = get_option("impacted_invalidate_all") or []
+    invalidate_dir = get_option("impacted_invalidate_dir") or []
     root_dir = config.rootdir
 
     disabled_ext = get_option("impacted_disable_ext") or []
     ext_config = _collect_ext_config(config)
     strategy = build_strategy_with_extensions(
         watch_dep_files=not no_dep_files,
+        invalidate_all_patterns=invalidate_all,
+        invalidate_dir_patterns=invalidate_dir,
         disabled=disabled_ext,
         ext_config=ext_config,
     )

--- a/pytest_impacted/plugin.py
+++ b/pytest_impacted/plugin.py
@@ -123,24 +123,6 @@ def pytest_addoption(parser: Parser):
         default=[],
     )
 
-    group.addoption(
-        "--impacted-invalidate-dir",
-        action="append",
-        default=[],
-        dest="impacted_invalidate_dir",
-        metavar="PATTERN",
-        help=(
-            "Glob pattern for files that, when changed, mark tests in the same directory "
-            "and below as impacted (like conftest.py). Repeatable."
-        ),
-    )
-    parser.addini(
-        "impacted_invalidate_dir",
-        help="default value for --impacted-invalidate-dir (list of glob patterns)",
-        type="args",
-        default=[],
-    )
-
     # Extension management
     group.addoption(
         "--impacted-disable-ext",
@@ -202,7 +184,6 @@ def pytest_report_header(config: Config) -> list[str]:
         f"impacted_tests_dir={get_option('impacted_tests_dir')}",
         f"no_impacted_dep_files={get_option('no_impacted_dep_files')}",
         f"impacted_invalidate_all={get_option('impacted_invalidate_all')}",
-        f"impacted_invalidate_dir={get_option('impacted_invalidate_dir')}",
         f"backend={backend}",
     ]
     if ext_names:
@@ -230,7 +211,6 @@ def pytest_collection_modifyitems(session, config, items):
     impacted_tests_dir = get_option("impacted_tests_dir")
     no_dep_files = get_option("no_impacted_dep_files")
     invalidate_all = get_option("impacted_invalidate_all") or []
-    invalidate_dir = get_option("impacted_invalidate_dir") or []
     root_dir = config.rootdir
 
     disabled_ext = get_option("impacted_disable_ext") or []
@@ -238,7 +218,6 @@ def pytest_collection_modifyitems(session, config, items):
     strategy = build_strategy_with_extensions(
         watch_dep_files=not no_dep_files,
         invalidate_all_patterns=invalidate_all,
-        invalidate_dir_patterns=invalidate_dir,
         disabled=disabled_ext,
         ext_config=ext_config,
     )

--- a/pytest_impacted/strategies.py
+++ b/pytest_impacted/strategies.py
@@ -139,9 +139,8 @@ def _is_under(path: Path, directory: Path) -> bool:
 def find_test_modules_under(directory: Path, dep_tree: nx.DiGraph, *, root_dir: Path) -> list[str]:
     """Return the sorted test modules whose files live in *directory* or any subdirectory.
 
-    This is the "same directory and below" impact rule shared by
-    :class:`PytestImpactStrategy` (for ``conftest.py``) and
-    :class:`InvalidationFileImpactStrategy` (for user-supplied patterns).
+    This is the "same directory and below" impact rule used by
+    :class:`PytestImpactStrategy` for ``conftest.py`` changes.
     """
     matches = []
     for test_module in dep_tree.nodes:
@@ -403,29 +402,20 @@ class InvalidationFileImpactStrategy(ImpactStrategy):
 
     Static import analysis cannot see that a test depends on a JSON fixture,
     a SQL schema, or a YAML config. This strategy lets users declare those
-    relationships with two kinds of pattern (see :func:`matches_any_glob`
-    for the matching rules):
+    relationships themselves: a change to any file matching one of
+    *patterns* marks **every** test module as impacted, exactly as a change
+    to ``pyproject.toml`` does. See :func:`matches_any_glob` for the
+    matching rules.
 
-    * ``all_patterns`` — a matching change marks **every** test module as
-      impacted, like a change to ``pyproject.toml`` does.
-    * ``dir_patterns`` — a matching change marks the test modules in the
-      changed file's directory **and below** as impacted, like a change to
-      ``conftest.py`` does.
-
-    Configured via ``--impacted-invalidate-all`` / ``--impacted-invalidate-dir``
-    (or the ``impacted_invalidate_all`` / ``impacted_invalidate_dir`` ini
-    settings) in the pytest plugin, and ``--invalidate-all`` /
-    ``--invalidate-dir`` in the ``impacted-tests`` CLI.
+    It is the user-extensible counterpart to
+    :class:`DependencyFileImpactStrategy`, configured via
+    ``--impacted-invalidate-all`` (or the ``impacted_invalidate_all`` ini
+    setting) in the pytest plugin, and ``--invalidate-all`` in the
+    ``impacted-tests`` CLI.
     """
 
-    def __init__(
-        self,
-        *,
-        all_patterns: Sequence[str] = (),
-        dir_patterns: Sequence[str] = (),
-    ):
-        self.all_patterns = tuple(all_patterns)
-        self.dir_patterns = tuple(dir_patterns)
+    def __init__(self, patterns: Sequence[str] = ()):
+        self.patterns = tuple(patterns)
 
     def find_impacted_tests(
         self,
@@ -438,16 +428,11 @@ class InvalidationFileImpactStrategy(ImpactStrategy):
         *,
         dep_tree: nx.DiGraph,
     ) -> list[str]:
-        """Return the union of the "all" and "directory" invalidation results."""
-        impacted: set[str] = set()
-        impacted.update(self._find_all_invalidated(changed_files, dep_tree, session))
-        impacted.update(self._find_dir_invalidated(changed_files, dep_tree, root_dir, session))
-        return sorted(impacted)
-
-    def _find_all_invalidated(self, changed_files: list[str], dep_tree: nx.DiGraph, session: Any) -> list[str]:
-        hits = [f for f in changed_files if matches_any_glob(f, self.all_patterns)]
+        """Return all test modules if any changed file matches a configured pattern."""
+        hits = [f for f in changed_files if matches_any_glob(f, self.patterns)]
         if not hits:
             return []
+
         all_test_modules = sorted(node for node in dep_tree.nodes if is_test_module(node))
         notify(
             f"Invalidation file changes detected: {hits} (matched --impacted-invalidate-all). "
@@ -456,35 +441,11 @@ class InvalidationFileImpactStrategy(ImpactStrategy):
         )
         return all_test_modules
 
-    def _find_dir_invalidated(
-        self, changed_files: list[str], dep_tree: nx.DiGraph, root_dir: Path | None, session: Any
-    ) -> list[str]:
-        hits = [f for f in changed_files if matches_any_glob(f, self.dir_patterns)]
-        if not hits:
-            return []
-        if root_dir is None:
-            logger.warning("Cannot apply --impacted-invalidate-dir patterns without a root_dir; ignoring %s.", hits)
-            return []
-
-        impacted: list[str] = []
-        for changed_file in hits:
-            changed_dir = _resolve_changed_file_dir(changed_file, root_dir)
-            if changed_dir is None:
-                continue
-            impacted.extend(find_test_modules_under(changed_dir, dep_tree, root_dir=root_dir))
-        notify(
-            f"Invalidation file changes detected: {hits} (matched --impacted-invalidate-dir). "
-            f"Marking {len(set(impacted))} test modules in the same directories as impacted.",
-            session,
-        )
-        return impacted
-
 
 def get_default_strategies(
     *,
     watch_dep_files: bool = True,
     invalidate_all_patterns: Sequence[str] = (),
-    invalidate_dir_patterns: Sequence[str] = (),
 ) -> list[ImpactStrategy]:
     """Return the default (built-in) strategy list for impact analysis.
 
@@ -494,12 +455,9 @@ def get_default_strategies(
 
     Args:
         watch_dep_files: Include :class:`DependencyFileImpactStrategy`.
-        invalidate_all_patterns: Globs for :class:`InvalidationFileImpactStrategy`
-            whose matches impact every test.
-        invalidate_dir_patterns: Globs for :class:`InvalidationFileImpactStrategy`
-            whose matches impact tests in the same directory and below. The
-            strategy is only added when at least one pattern of either kind
-            is given.
+        invalidate_all_patterns: Globs for :class:`InvalidationFileImpactStrategy`,
+            whose matches impact every test. The strategy is only added to the
+            pipeline when at least one pattern is given.
     """
     strategies: list[ImpactStrategy] = [
         ASTImpactStrategy(),
@@ -507,13 +465,8 @@ def get_default_strategies(
     ]
     if watch_dep_files:
         strategies.append(DependencyFileImpactStrategy())
-    if invalidate_all_patterns or invalidate_dir_patterns:
-        strategies.append(
-            InvalidationFileImpactStrategy(
-                all_patterns=invalidate_all_patterns,
-                dir_patterns=invalidate_dir_patterns,
-            )
-        )
+    if invalidate_all_patterns:
+        strategies.append(InvalidationFileImpactStrategy(invalidate_all_patterns))
     return strategies
 
 

--- a/pytest_impacted/strategies.py
+++ b/pytest_impacted/strategies.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Sequence
 from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 
 import networkx as nx
 
+from pytest_impacted.display import notify
 from pytest_impacted.graph import build_dep_tree, resolve_impacted_tests
 from pytest_impacted.parsing import is_test_module, normalize_path
 from pytest_impacted.traversal import discover_submodules
@@ -40,6 +42,19 @@ DEFAULT_DEPENDENCY_GLOB_PATTERNS: tuple[str, ...] = (
 )
 
 
+def matches_any_glob(file_path: str, glob_patterns: Iterable[str]) -> bool:
+    """Check if a repo-relative file path matches any glob pattern.
+
+    Matching is right-anchored (:meth:`PurePosixPath.match`): ``*.json``
+    matches a JSON file at any depth, ``config/*.json`` matches JSON files
+    directly under any ``config`` directory, and a bare filename matches
+    that basename anywhere. This is the single matching convention for both
+    built-in and user-supplied file patterns.
+    """
+    path = PurePosixPath(file_path)
+    return any(path.match(glob_pat) for glob_pat in glob_patterns)
+
+
 def matches_dependency_file(
     file_path: str,
     patterns: tuple[str, ...] = DEFAULT_DEPENDENCY_FILE_PATTERNS,
@@ -49,7 +64,7 @@ def matches_dependency_file(
     basename = PurePosixPath(file_path).name
     if basename in patterns:
         return True
-    return any(PurePosixPath(file_path).match(glob_pat) for glob_pat in glob_patterns)
+    return matches_any_glob(file_path, glob_patterns)
 
 
 def has_dependency_file_changes(
@@ -90,6 +105,52 @@ def clear_dep_tree_cache() -> None:
     """
     cached_build_dep_tree.cache_clear()
     discover_submodules.cache_clear()
+
+
+def _resolve_changed_file_dir(changed_file: str, root_dir: Path) -> Path | None:
+    """Return the absolute directory containing *changed_file*, or None if unresolvable."""
+    try:
+        path = normalize_path(changed_file)
+    except ValueError:
+        return None
+    if not path.is_absolute():
+        path = normalize_path(root_dir) / path
+    return path.parent
+
+
+def _test_module_path(test_module: str, root_dir: Path) -> Path | None:
+    """Locate the source file for a dotted test module name under *root_dir*."""
+    module_path = "/".join(test_module.split("."))
+    root_path = normalize_path(root_dir)
+    for candidate in (root_path / (module_path + ".py"), root_path / module_path / "__init__.py"):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _is_under(path: Path, directory: Path) -> bool:
+    try:
+        path.resolve().relative_to(directory.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def find_test_modules_under(directory: Path, dep_tree: nx.DiGraph, *, root_dir: Path) -> list[str]:
+    """Return the sorted test modules whose files live in *directory* or any subdirectory.
+
+    This is the "same directory and below" impact rule shared by
+    :class:`PytestImpactStrategy` (for ``conftest.py``) and
+    :class:`InvalidationFileImpactStrategy` (for user-supplied patterns).
+    """
+    matches = []
+    for test_module in dep_tree.nodes:
+        if not is_test_module(test_module):
+            continue
+        path = _test_module_path(test_module, root_dir)
+        if path is not None and _is_under(path, directory):
+            matches.append(test_module)
+    return sorted(matches)
 
 
 class ImpactStrategy(ABC):
@@ -284,60 +345,15 @@ class PytestImpactStrategy(ImpactStrategy):
         if not root_dir:
             return []
 
-        conftest_files = [f for f in changed_files if f.endswith("conftest.py")]
-        if not conftest_files:
-            return []
-
         impacted_tests: list[str] = []
-
-        for conftest_file in conftest_files:
-            try:
-                conftest_path = normalize_path(conftest_file)
-
-                if not conftest_path.is_absolute():
-                    conftest_path = normalize_path(root_dir) / conftest_path
-
-                conftest_dir = conftest_path.parent
-            except ValueError:
+        for conftest_file in (f for f in changed_files if f.endswith("conftest.py")):
+            conftest_dir = _resolve_changed_file_dir(conftest_file, root_dir)
+            if conftest_dir is None:
                 # Skip files that can't be normalized to valid paths
                 continue
-
-            # Find all test modules in subdirectories that could be affected
-            impacted_tests.extend(
-                test_module
-                for test_module in dep_tree.nodes
-                if is_test_module(test_module)
-                and self._is_test_affected_by_conftest(test_module, conftest_dir, root_dir)
-            )
+            impacted_tests.extend(find_test_modules_under(conftest_dir, dep_tree, root_dir=root_dir))
 
         return impacted_tests
-
-    def _is_test_affected_by_conftest(self, test_module: str, conftest_dir: Path, root_dir: Path) -> bool:
-        """Check if a test module is affected by a conftest.py change."""
-        # Convert module name to file path
-        module_parts = test_module.split(".")
-
-        # Try to find the actual file path for this test module
-        module_path = "/".join(module_parts)
-        root_path = normalize_path(root_dir)
-        possible_paths = [
-            root_path / (module_path + ".py"),
-            root_path / module_path / "__init__.py",
-        ]
-
-        # Check if any of the possible paths exist and are affected by conftest
-        for path in possible_paths:
-            if path.exists():
-                try:
-                    # Check if the test file is in the same directory or a subdirectory
-                    # of where the conftest.py was changed
-                    path.resolve().relative_to(conftest_dir.resolve())
-                    return True
-                except ValueError:
-                    # path is not relative to conftest_dir
-                    continue
-
-        return False
 
 
 class DependencyFileImpactStrategy(ImpactStrategy):
@@ -373,8 +389,6 @@ class DependencyFileImpactStrategy(ImpactStrategy):
         all_test_modules = sorted(node for node in dep_tree.nodes if is_test_module(node))
 
         dep_files = [f for f in changed_files if matches_dependency_file(f, self.patterns, self.glob_patterns)]
-        from pytest_impacted.display import notify  # noqa: PLC0415
-
         notify(
             f"Dependency file changes detected: {dep_files}. "
             f"Marking all {len(all_test_modules)} test modules as impacted.",
@@ -384,12 +398,108 @@ class DependencyFileImpactStrategy(ImpactStrategy):
         return all_test_modules
 
 
-def get_default_strategies(*, watch_dep_files: bool = True) -> list[ImpactStrategy]:
+class InvalidationFileImpactStrategy(ImpactStrategy):
+    """Strategy driven by user-supplied glob patterns for non-Python files.
+
+    Static import analysis cannot see that a test depends on a JSON fixture,
+    a SQL schema, or a YAML config. This strategy lets users declare those
+    relationships with two kinds of pattern (see :func:`matches_any_glob`
+    for the matching rules):
+
+    * ``all_patterns`` — a matching change marks **every** test module as
+      impacted, like a change to ``pyproject.toml`` does.
+    * ``dir_patterns`` — a matching change marks the test modules in the
+      changed file's directory **and below** as impacted, like a change to
+      ``conftest.py`` does.
+
+    Configured via ``--impacted-invalidate-all`` / ``--impacted-invalidate-dir``
+    (or the ``impacted_invalidate_all`` / ``impacted_invalidate_dir`` ini
+    settings) in the pytest plugin, and ``--invalidate-all`` /
+    ``--invalidate-dir`` in the ``impacted-tests`` CLI.
+    """
+
+    def __init__(
+        self,
+        *,
+        all_patterns: Sequence[str] = (),
+        dir_patterns: Sequence[str] = (),
+    ):
+        self.all_patterns = tuple(all_patterns)
+        self.dir_patterns = tuple(dir_patterns)
+
+    def find_impacted_tests(
+        self,
+        changed_files: list[str],
+        impacted_modules: list[str],
+        ns_module: str,
+        tests_package: str | None = None,
+        root_dir: Path | None = None,
+        session: Any = None,
+        *,
+        dep_tree: nx.DiGraph,
+    ) -> list[str]:
+        """Return the union of the "all" and "directory" invalidation results."""
+        impacted: set[str] = set()
+        impacted.update(self._find_all_invalidated(changed_files, dep_tree, session))
+        impacted.update(self._find_dir_invalidated(changed_files, dep_tree, root_dir, session))
+        return sorted(impacted)
+
+    def _find_all_invalidated(self, changed_files: list[str], dep_tree: nx.DiGraph, session: Any) -> list[str]:
+        hits = [f for f in changed_files if matches_any_glob(f, self.all_patterns)]
+        if not hits:
+            return []
+        all_test_modules = sorted(node for node in dep_tree.nodes if is_test_module(node))
+        notify(
+            f"Invalidation file changes detected: {hits} (matched --impacted-invalidate-all). "
+            f"Marking all {len(all_test_modules)} test modules as impacted.",
+            session,
+        )
+        return all_test_modules
+
+    def _find_dir_invalidated(
+        self, changed_files: list[str], dep_tree: nx.DiGraph, root_dir: Path | None, session: Any
+    ) -> list[str]:
+        hits = [f for f in changed_files if matches_any_glob(f, self.dir_patterns)]
+        if not hits:
+            return []
+        if root_dir is None:
+            logger.warning("Cannot apply --impacted-invalidate-dir patterns without a root_dir; ignoring %s.", hits)
+            return []
+
+        impacted: list[str] = []
+        for changed_file in hits:
+            changed_dir = _resolve_changed_file_dir(changed_file, root_dir)
+            if changed_dir is None:
+                continue
+            impacted.extend(find_test_modules_under(changed_dir, dep_tree, root_dir=root_dir))
+        notify(
+            f"Invalidation file changes detected: {hits} (matched --impacted-invalidate-dir). "
+            f"Marking {len(set(impacted))} test modules in the same directories as impacted.",
+            session,
+        )
+        return impacted
+
+
+def get_default_strategies(
+    *,
+    watch_dep_files: bool = True,
+    invalidate_all_patterns: Sequence[str] = (),
+    invalidate_dir_patterns: Sequence[str] = (),
+) -> list[ImpactStrategy]:
     """Return the default (built-in) strategy list for impact analysis.
 
     This centralizes the knowledge of which built-in strategies form the
     default pipeline. Third-party extensions are added separately via
     :func:`~pytest_impacted.extensions.build_strategy_with_extensions`.
+
+    Args:
+        watch_dep_files: Include :class:`DependencyFileImpactStrategy`.
+        invalidate_all_patterns: Globs for :class:`InvalidationFileImpactStrategy`
+            whose matches impact every test.
+        invalidate_dir_patterns: Globs for :class:`InvalidationFileImpactStrategy`
+            whose matches impact tests in the same directory and below. The
+            strategy is only added when at least one pattern of either kind
+            is given.
     """
     strategies: list[ImpactStrategy] = [
         ASTImpactStrategy(),
@@ -397,6 +507,13 @@ def get_default_strategies(*, watch_dep_files: bool = True) -> list[ImpactStrate
     ]
     if watch_dep_files:
         strategies.append(DependencyFileImpactStrategy())
+    if invalidate_all_patterns or invalidate_dir_patterns:
+        strategies.append(
+            InvalidationFileImpactStrategy(
+                all_patterns=invalidate_all_patterns,
+                dir_patterns=invalidate_dir_patterns,
+            )
+        )
     return strategies
 
 

--- a/tests/strategies/test_invalidation_file_impact.py
+++ b/tests/strategies/test_invalidation_file_impact.py
@@ -1,7 +1,6 @@
 """Unit-tests for the user-configurable file invalidation strategy."""
 
 import logging
-from pathlib import Path
 
 import networkx as nx
 import pytest
@@ -9,7 +8,6 @@ import pytest
 from pytest_impacted.strategies import (
     DependencyFileImpactStrategy,
     InvalidationFileImpactStrategy,
-    find_test_modules_under,
     get_default_strategies,
     matches_any_glob,
 )
@@ -30,6 +28,10 @@ class TestMatchesAnyGlob:
             pytest.param("schema.graphql", "schema.graphql", True, id="bare_filename"),
             pytest.param("src/schema.graphql", "schema.graphql", True, id="bare_filename_matches_basename"),
             pytest.param("settings.json5", "*.json", False, id="no_partial_match"),
+            # PurePath.match treats "**" as a plain "*" — it is NOT recursive. Documented
+            # in docs/usage.md; pinned here so a matcher change cannot silently break it.
+            pytest.param("config/a/x.yaml", "config/**/*.yaml", True, id="double_star_is_one_segment"),
+            pytest.param("config/a/b/x.yaml", "config/**/*.yaml", False, id="double_star_does_not_recurse"),
         ],
     )
     def test_patterns(self, file_path, glob_pattern, expected):
@@ -40,44 +42,20 @@ class TestMatchesAnyGlob:
 
 
 @pytest.fixture
-def project(tmp_path: Path) -> Path:
-    """A tiny on-disk layout so directory-scoped matching can resolve test module paths."""
-    for rel in ("tests/unit/test_a.py", "tests/unit/deep/test_b.py", "tests/integration/test_c.py"):
-        path = tmp_path / rel
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("")
-    (tmp_path / "tests" / "unit" / "fixtures").mkdir()
-    return tmp_path
-
-
-@pytest.fixture
 def dep_tree() -> nx.DiGraph:
     graph = nx.DiGraph()
     graph.add_nodes_from(["pkg.core", "tests.unit.test_a", "tests.unit.deep.test_b", "tests.integration.test_c"])
     return graph
 
 
-class TestFindTestModulesUnder:
-    def test_returns_tests_in_dir_and_below(self, project, dep_tree):
-        result = find_test_modules_under(project / "tests" / "unit", dep_tree, root_dir=project)
-        assert result == ["tests.unit.deep.test_b", "tests.unit.test_a"]
-
-    def test_root_returns_everything(self, project, dep_tree):
-        result = find_test_modules_under(project, dep_tree, root_dir=project)
-        assert result == ["tests.integration.test_c", "tests.unit.deep.test_b", "tests.unit.test_a"]
-
-    def test_unrelated_dir_returns_nothing(self, project, dep_tree):
-        assert find_test_modules_under(project / "docs", dep_tree, root_dir=project) == []
-
-
 class TestInvalidationFileImpactStrategy:
-    def _run(self, strategy, changed_files, dep_tree, root_dir=None):
+    def _run(self, strategy, changed_files, dep_tree):
         return strategy.find_impacted_tests(
             changed_files=changed_files,
             impacted_modules=[],
             ns_module="pkg",
             tests_package="tests",
-            root_dir=root_dir,
+            root_dir=None,
             dep_tree=dep_tree,
         )
 
@@ -85,46 +63,28 @@ class TestInvalidationFileImpactStrategy:
         strategy = InvalidationFileImpactStrategy()
         assert self._run(strategy, ["config/settings.json", "uv.lock"], dep_tree) == []
 
-    def test_all_pattern_returns_every_test_module(self, dep_tree):
-        strategy = InvalidationFileImpactStrategy(all_patterns=("*.json",))
+    def test_match_returns_every_test_module(self, dep_tree):
+        strategy = InvalidationFileImpactStrategy(("*.json",))
         result = self._run(strategy, ["config/settings.json"], dep_tree)
         assert result == ["tests.integration.test_c", "tests.unit.deep.test_b", "tests.unit.test_a"]
 
-    def test_all_pattern_no_match_returns_nothing(self, dep_tree):
-        strategy = InvalidationFileImpactStrategy(all_patterns=("*.json",))
+    def test_no_match_returns_nothing(self, dep_tree):
+        strategy = InvalidationFileImpactStrategy(("*.json",))
         assert self._run(strategy, ["config/settings.yaml", "pkg/core.py"], dep_tree) == []
 
-    def test_dir_pattern_returns_tests_under_changed_file_directory(self, project, dep_tree):
-        strategy = InvalidationFileImpactStrategy(dir_patterns=("*.json",))
-        result = self._run(strategy, ["tests/unit/fixtures/data.json"], dep_tree, root_dir=project)
-        # fixtures/ itself has no tests; nothing above it is included.
-        assert result == []
+    def test_any_of_several_patterns_may_match(self, dep_tree):
+        strategy = InvalidationFileImpactStrategy(("*.lock", "config/*.yaml"))
+        every_test = ["tests.integration.test_c", "tests.unit.deep.test_b", "tests.unit.test_a"]
+        assert self._run(strategy, ["config/settings.yaml"], dep_tree) == every_test
+        assert self._run(strategy, ["custom.lock"], dep_tree) == every_test
 
-        result = self._run(strategy, ["tests/unit/data.json"], dep_tree, root_dir=project)
-        assert result == ["tests.unit.deep.test_b", "tests.unit.test_a"]
-
-    def test_dir_pattern_accepts_absolute_changed_paths(self, project, dep_tree):
-        strategy = InvalidationFileImpactStrategy(dir_patterns=("*.json",))
-        result = self._run(strategy, [str(project / "tests" / "integration" / "x.json")], dep_tree, root_dir=project)
-        assert result == ["tests.integration.test_c"]
-
-    def test_dir_pattern_without_root_dir_returns_nothing(self, dep_tree):
-        strategy = InvalidationFileImpactStrategy(dir_patterns=("*.json",))
-        assert self._run(strategy, ["tests/unit/data.json"], dep_tree, root_dir=None) == []
-
-    def test_all_and_dir_results_are_unioned_and_sorted(self, project, dep_tree):
-        strategy = InvalidationFileImpactStrategy(all_patterns=("*.lock",), dir_patterns=("*.json",))
-        result = self._run(strategy, ["tests/unit/data.json", "custom.lock"], dep_tree, root_dir=project)
-        assert result == ["tests.integration.test_c", "tests.unit.deep.test_b", "tests.unit.test_a"]
-
-    def test_notifies_which_files_triggered(self, project, dep_tree, caplog):
-        strategy = InvalidationFileImpactStrategy(all_patterns=("*.lock",), dir_patterns=("*.json",))
+    def test_notifies_which_files_triggered(self, dep_tree, caplog):
+        strategy = InvalidationFileImpactStrategy(("*.lock",))
         with caplog.at_level(logging.INFO, logger="pytest_impacted.display"):
-            self._run(strategy, ["custom.lock", "tests/unit/data.json"], dep_tree, root_dir=project)
+            self._run(strategy, ["custom.lock", "pkg/core.py"], dep_tree)
         assert "custom.lock" in caplog.text
+        assert "pkg/core.py" not in caplog.text
         assert "--impacted-invalidate-all" in caplog.text
-        assert "tests/unit/data.json" in caplog.text
-        assert "--impacted-invalidate-dir" in caplog.text
 
 
 class TestGetDefaultStrategies:
@@ -137,13 +97,7 @@ class TestGetDefaultStrategies:
         assert isinstance(strategies[-2], DependencyFileImpactStrategy)
         strategy = strategies[-1]
         assert isinstance(strategy, InvalidationFileImpactStrategy)
-        assert strategy.all_patterns == ("*.json",)
-        assert strategy.dir_patterns == ()
-
-    def test_dir_patterns_alone_are_enough(self):
-        strategy = get_default_strategies(invalidate_dir_patterns=("*.yaml",))[-1]
-        assert isinstance(strategy, InvalidationFileImpactStrategy)
-        assert strategy.dir_patterns == ("*.yaml",)
+        assert strategy.patterns == ("*.json",)
 
     def test_independent_of_dep_file_switch(self):
         strategies = get_default_strategies(watch_dep_files=False, invalidate_all_patterns=["*.json"])

--- a/tests/strategies/test_invalidation_file_impact.py
+++ b/tests/strategies/test_invalidation_file_impact.py
@@ -1,0 +1,151 @@
+"""Unit-tests for the user-configurable file invalidation strategy."""
+
+import logging
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from pytest_impacted.strategies import (
+    DependencyFileImpactStrategy,
+    InvalidationFileImpactStrategy,
+    find_test_modules_under,
+    get_default_strategies,
+    matches_any_glob,
+)
+
+
+class TestMatchesAnyGlob:
+    """Test the shared glob matcher used for user-supplied patterns."""
+
+    @pytest.mark.parametrize(
+        ("file_path", "glob_pattern", "expected"),
+        [
+            pytest.param("settings.json", "*.json", True, id="extension_glob_at_root"),
+            pytest.param("config/nested/settings.json", "*.json", True, id="extension_glob_nested"),
+            pytest.param("config/settings.json", "config/*.json", True, id="dir_scoped_glob"),
+            pytest.param("other/settings.json", "config/*.json", False, id="dir_scoped_glob_wrong_dir"),
+            pytest.param("fixtures/a/data.yaml", "fixtures/*/*.yaml", True, id="two_level_glob"),
+            pytest.param("fixtures/a/b/data.yaml", "fixtures/*/*.yaml", False, id="star_spans_one_segment"),
+            pytest.param("schema.graphql", "schema.graphql", True, id="bare_filename"),
+            pytest.param("src/schema.graphql", "schema.graphql", True, id="bare_filename_matches_basename"),
+            pytest.param("settings.json5", "*.json", False, id="no_partial_match"),
+        ],
+    )
+    def test_patterns(self, file_path, glob_pattern, expected):
+        assert matches_any_glob(file_path, (glob_pattern,)) is expected
+
+    def test_empty_patterns_never_match(self):
+        assert matches_any_glob("anything.json", ()) is False
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A tiny on-disk layout so directory-scoped matching can resolve test module paths."""
+    for rel in ("tests/unit/test_a.py", "tests/unit/deep/test_b.py", "tests/integration/test_c.py"):
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("")
+    (tmp_path / "tests" / "unit" / "fixtures").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def dep_tree() -> nx.DiGraph:
+    graph = nx.DiGraph()
+    graph.add_nodes_from(["pkg.core", "tests.unit.test_a", "tests.unit.deep.test_b", "tests.integration.test_c"])
+    return graph
+
+
+class TestFindTestModulesUnder:
+    def test_returns_tests_in_dir_and_below(self, project, dep_tree):
+        result = find_test_modules_under(project / "tests" / "unit", dep_tree, root_dir=project)
+        assert result == ["tests.unit.deep.test_b", "tests.unit.test_a"]
+
+    def test_root_returns_everything(self, project, dep_tree):
+        result = find_test_modules_under(project, dep_tree, root_dir=project)
+        assert result == ["tests.integration.test_c", "tests.unit.deep.test_b", "tests.unit.test_a"]
+
+    def test_unrelated_dir_returns_nothing(self, project, dep_tree):
+        assert find_test_modules_under(project / "docs", dep_tree, root_dir=project) == []
+
+
+class TestInvalidationFileImpactStrategy:
+    def _run(self, strategy, changed_files, dep_tree, root_dir=None):
+        return strategy.find_impacted_tests(
+            changed_files=changed_files,
+            impacted_modules=[],
+            ns_module="pkg",
+            tests_package="tests",
+            root_dir=root_dir,
+            dep_tree=dep_tree,
+        )
+
+    def test_no_patterns_is_a_no_op(self, dep_tree):
+        strategy = InvalidationFileImpactStrategy()
+        assert self._run(strategy, ["config/settings.json", "uv.lock"], dep_tree) == []
+
+    def test_all_pattern_returns_every_test_module(self, dep_tree):
+        strategy = InvalidationFileImpactStrategy(all_patterns=("*.json",))
+        result = self._run(strategy, ["config/settings.json"], dep_tree)
+        assert result == ["tests.integration.test_c", "tests.unit.deep.test_b", "tests.unit.test_a"]
+
+    def test_all_pattern_no_match_returns_nothing(self, dep_tree):
+        strategy = InvalidationFileImpactStrategy(all_patterns=("*.json",))
+        assert self._run(strategy, ["config/settings.yaml", "pkg/core.py"], dep_tree) == []
+
+    def test_dir_pattern_returns_tests_under_changed_file_directory(self, project, dep_tree):
+        strategy = InvalidationFileImpactStrategy(dir_patterns=("*.json",))
+        result = self._run(strategy, ["tests/unit/fixtures/data.json"], dep_tree, root_dir=project)
+        # fixtures/ itself has no tests; nothing above it is included.
+        assert result == []
+
+        result = self._run(strategy, ["tests/unit/data.json"], dep_tree, root_dir=project)
+        assert result == ["tests.unit.deep.test_b", "tests.unit.test_a"]
+
+    def test_dir_pattern_accepts_absolute_changed_paths(self, project, dep_tree):
+        strategy = InvalidationFileImpactStrategy(dir_patterns=("*.json",))
+        result = self._run(strategy, [str(project / "tests" / "integration" / "x.json")], dep_tree, root_dir=project)
+        assert result == ["tests.integration.test_c"]
+
+    def test_dir_pattern_without_root_dir_returns_nothing(self, dep_tree):
+        strategy = InvalidationFileImpactStrategy(dir_patterns=("*.json",))
+        assert self._run(strategy, ["tests/unit/data.json"], dep_tree, root_dir=None) == []
+
+    def test_all_and_dir_results_are_unioned_and_sorted(self, project, dep_tree):
+        strategy = InvalidationFileImpactStrategy(all_patterns=("*.lock",), dir_patterns=("*.json",))
+        result = self._run(strategy, ["tests/unit/data.json", "custom.lock"], dep_tree, root_dir=project)
+        assert result == ["tests.integration.test_c", "tests.unit.deep.test_b", "tests.unit.test_a"]
+
+    def test_notifies_which_files_triggered(self, project, dep_tree, caplog):
+        strategy = InvalidationFileImpactStrategy(all_patterns=("*.lock",), dir_patterns=("*.json",))
+        with caplog.at_level(logging.INFO, logger="pytest_impacted.display"):
+            self._run(strategy, ["custom.lock", "tests/unit/data.json"], dep_tree, root_dir=project)
+        assert "custom.lock" in caplog.text
+        assert "--impacted-invalidate-all" in caplog.text
+        assert "tests/unit/data.json" in caplog.text
+        assert "--impacted-invalidate-dir" in caplog.text
+
+
+class TestGetDefaultStrategies:
+    def test_not_included_without_patterns(self):
+        strategies = get_default_strategies()
+        assert not any(isinstance(s, InvalidationFileImpactStrategy) for s in strategies)
+
+    def test_included_after_dep_file_strategy_when_configured(self):
+        strategies = get_default_strategies(invalidate_all_patterns=["*.json"])
+        assert isinstance(strategies[-2], DependencyFileImpactStrategy)
+        strategy = strategies[-1]
+        assert isinstance(strategy, InvalidationFileImpactStrategy)
+        assert strategy.all_patterns == ("*.json",)
+        assert strategy.dir_patterns == ()
+
+    def test_dir_patterns_alone_are_enough(self):
+        strategy = get_default_strategies(invalidate_dir_patterns=("*.yaml",))[-1]
+        assert isinstance(strategy, InvalidationFileImpactStrategy)
+        assert strategy.dir_patterns == ("*.yaml",)
+
+    def test_independent_of_dep_file_switch(self):
+        strategies = get_default_strategies(watch_dep_files=False, invalidate_all_patterns=["*.json"])
+        assert not any(isinstance(s, DependencyFileImpactStrategy) for s in strategies)
+        assert isinstance(strategies[-1], InvalidationFileImpactStrategy)

--- a/tests/strategies/test_pytest_impact.py
+++ b/tests/strategies/test_pytest_impact.py
@@ -4,8 +4,11 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import networkx as nx
+
 from pytest_impacted.strategies import (
     PytestImpactStrategy,
+    find_test_modules_under,
 )
 
 
@@ -74,27 +77,20 @@ class TestPytestImpactStrategy:
         assert "tests.subdir.test_example" in result
         assert "tests.test_other" not in result  # This one is not in a subdirectory
 
-    def test_is_test_affected_by_conftest(self):
-        """Test the conftest impact detection logic."""
+    def test_find_test_modules_under_conftest_dir(self):
+        """The conftest rule uses the shared "same directory and below" helper."""
         # Create test directory structure
         test_dir = self.root_dir / "tests"
         test_dir.mkdir()
         subdir = test_dir / "subdir"
         subdir.mkdir()
-        test_file = subdir / "test_example.py"
-        test_file.touch()
-
-        strategy = PytestImpactStrategy()
-
-        # Test module in subdirectory should be affected
-        result = strategy._is_test_affected_by_conftest("tests.subdir.test_example", test_dir, self.root_dir)
-        assert result is True
-
-        # Test module in sibling directory should not be affected
+        (subdir / "test_example.py").touch()
         other_dir = self.root_dir / "other_tests"
         other_dir.mkdir()
-        other_test_file = other_dir / "test_other.py"
-        other_test_file.touch()
+        (other_dir / "test_other.py").touch()
 
-        result = strategy._is_test_affected_by_conftest("other_tests.test_other", test_dir, self.root_dir)
-        assert result is False
+        dep_tree = nx.DiGraph()
+        dep_tree.add_nodes_from(["tests.subdir.test_example", "other_tests.test_other", "mypackage.core"])
+
+        # Only the module in a subdirectory of the conftest dir is affected
+        assert find_test_modules_under(test_dir, dep_tree, root_dir=self.root_dir) == ["tests.subdir.test_example"]

--- a/tests/strategies/test_pytest_impact.py
+++ b/tests/strategies/test_pytest_impact.py
@@ -94,3 +94,11 @@ class TestPytestImpactStrategy:
 
         # Only the module in a subdirectory of the conftest dir is affected
         assert find_test_modules_under(test_dir, dep_tree, root_dir=self.root_dir) == ["tests.subdir.test_example"]
+
+        # A conftest at the repo root reaches every test module...
+        assert find_test_modules_under(self.root_dir, dep_tree, root_dir=self.root_dir) == [
+            "other_tests.test_other",
+            "tests.subdir.test_example",
+        ]
+        # ...and a directory holding no tests reaches none.
+        assert find_test_modules_under(self.root_dir / "docs", dep_tree, root_dir=self.root_dir) == []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -288,6 +288,36 @@ def test_get_impacted_tests_dep_file_with_watch_disabled(
 @patch("pytest_impacted.api.find_impacted_files_in_repo")
 @patch("pytest_impacted.api.resolve_files_to_modules")
 @patch("pytest_impacted.api.resolve_modules_to_files")
+@patch("pytest_impacted.api.cached_build_dep_tree")
+def test_get_impacted_tests_invalidate_all_patterns(
+    mock_cached_build_dep_tree,
+    mock_resolve_modules_to_files,
+    mock_resolve_files_to_modules,
+    mock_find_impacted_files,
+):
+    """A changed file matching a user-supplied invalidation pattern marks every test module as impacted."""
+    dep_tree = nx.DiGraph()
+    dep_tree.add_nodes_from(["project_ns.core", "tests.test_core", "tests.test_other"])
+    mock_cached_build_dep_tree.return_value = dep_tree
+    mock_find_impacted_files.return_value = ["config/settings.json"]
+    mock_resolve_files_to_modules.return_value = []
+    mock_resolve_modules_to_files.side_effect = lambda modules, **_: [m.replace(".", "/") + ".py" for m in modules]
+
+    result = get_impacted_tests(
+        impacted_git_mode=GitMode.UNSTAGED,
+        impacted_base_branch="main",
+        root_dir=Path("."),
+        ns_module="project_ns",
+        tests_dir="tests",
+        invalidate_all_patterns=["*.json"],
+    )
+
+    assert result == ["tests/test_core.py", "tests/test_other.py"]
+
+
+@patch("pytest_impacted.api.find_impacted_files_in_repo")
+@patch("pytest_impacted.api.resolve_files_to_modules")
+@patch("pytest_impacted.api.resolve_modules_to_files")
 def test_get_impacted_tests_mixed_dep_and_py_changes(
     mock_resolve_modules_to_files,
     mock_resolve_files_to_modules,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,43 @@ class TestImpactedTestsCLI:
             assert "tests/test_example.py" in result.output
             assert "tests/test_other.py" in result.output
 
+    @patch("pytest_impacted.cli.build_strategy_with_extensions")
+    @patch("pytest_impacted.cli.get_impacted_tests")
+    @patch("pytest_impacted.cli.configure_logging")
+    def test_cli_invalidate_options_are_repeatable(
+        self, mock_configure_logging, mock_get_impacted_tests, mock_build_strategy
+    ):
+        """Each --invalidate-all / --invalidate-dir value is forwarded to the strategy builder."""
+        mock_get_impacted_tests.return_value = []
+
+        with self.runner.isolated_filesystem():
+            Path("test_ns").mkdir()
+
+            result = self.runner.invoke(
+                impacted_tests_cli,
+                [
+                    "--module",
+                    "test_ns",
+                    "--invalidate-all",
+                    "*.json",
+                    "--invalidate-all",
+                    "config/*.yaml",
+                    "--invalidate-dir",
+                    "*.sql",
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_build_strategy.assert_called_once_with(
+                watch_dep_files=True,
+                invalidate_all_patterns=("*.json", "config/*.yaml"),
+                invalidate_dir_patterns=("*.sql",),
+                disabled=(),
+                ext_config={},
+            )
+            assert "invalidate-all: *.json, config/*.yaml" in result.output
+            assert "invalidate-dir: *.sql" in result.output
+
     @patch("pytest_impacted.cli.get_impacted_tests")
     @patch("pytest_impacted.cli.configure_logging")
     def test_cli_with_tests_dir(self, mock_configure_logging, mock_get_impacted_tests):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,10 +95,10 @@ class TestImpactedTestsCLI:
     @patch("pytest_impacted.cli.build_strategy_with_extensions")
     @patch("pytest_impacted.cli.get_impacted_tests")
     @patch("pytest_impacted.cli.configure_logging")
-    def test_cli_invalidate_options_are_repeatable(
+    def test_cli_invalidate_all_is_repeatable(
         self, mock_configure_logging, mock_get_impacted_tests, mock_build_strategy
     ):
-        """Each --invalidate-all / --invalidate-dir value is forwarded to the strategy builder."""
+        """Each --invalidate-all value is forwarded to the strategy builder."""
         mock_get_impacted_tests.return_value = []
 
         with self.runner.isolated_filesystem():
@@ -113,8 +113,6 @@ class TestImpactedTestsCLI:
                     "*.json",
                     "--invalidate-all",
                     "config/*.yaml",
-                    "--invalidate-dir",
-                    "*.sql",
                 ],
             )
 
@@ -122,12 +120,10 @@ class TestImpactedTestsCLI:
             mock_build_strategy.assert_called_once_with(
                 watch_dep_files=True,
                 invalidate_all_patterns=("*.json", "config/*.yaml"),
-                invalidate_dir_patterns=("*.sql",),
                 disabled=(),
                 ext_config={},
             )
             assert "invalidate-all: *.json, config/*.yaml" in result.output
-            assert "invalidate-dir: *.sql" in result.output
 
     @patch("pytest_impacted.cli.get_impacted_tests")
     @patch("pytest_impacted.cli.configure_logging")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -478,13 +478,10 @@ class TestBuildStrategyWithExtensions:
     @patch("pytest_impacted.extensions.importlib.metadata.entry_points")
     def test_invalidation_patterns_reach_builtin_strategy(self, mock_entry_points):
         mock_entry_points.return_value = [_make_mock_entry_point("simple", SimpleStrategy)]
-        strategy = build_strategy_with_extensions(
-            invalidate_all_patterns=("*.json",), invalidate_dir_patterns=("*.yaml",)
-        )
+        strategy = build_strategy_with_extensions(invalidate_all_patterns=("*.json",))
         # Built-ins (now 4) still precede extensions.
         assert isinstance(strategy.strategies[3], InvalidationFileImpactStrategy)
-        assert strategy.strategies[3].all_patterns == ("*.json",)
-        assert strategy.strategies[3].dir_patterns == ("*.yaml",)
+        assert strategy.strategies[3].patterns == ("*.json",)
         assert isinstance(strategy.strategies[4], SimpleStrategy)
 
     @patch("pytest_impacted.extensions.importlib.metadata.entry_points")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -24,6 +24,7 @@ from pytest_impacted.strategies import (
     CompositeImpactStrategy,
     DependencyFileImpactStrategy,
     ImpactStrategy,
+    InvalidationFileImpactStrategy,
     PytestImpactStrategy,
 )
 
@@ -473,6 +474,18 @@ class TestBuildStrategyWithExtensions:
         mock_entry_points.return_value = []
         strategy = build_strategy_with_extensions(watch_dep_files=False)
         assert len(strategy.strategies) == 2
+
+    @patch("pytest_impacted.extensions.importlib.metadata.entry_points")
+    def test_invalidation_patterns_reach_builtin_strategy(self, mock_entry_points):
+        mock_entry_points.return_value = [_make_mock_entry_point("simple", SimpleStrategy)]
+        strategy = build_strategy_with_extensions(
+            invalidate_all_patterns=("*.json",), invalidate_dir_patterns=("*.yaml",)
+        )
+        # Built-ins (now 4) still precede extensions.
+        assert isinstance(strategy.strategies[3], InvalidationFileImpactStrategy)
+        assert strategy.strategies[3].all_patterns == ("*.json",)
+        assert strategy.strategies[3].dir_patterns == ("*.yaml",)
+        assert isinstance(strategy.strategies[4], SimpleStrategy)
 
     @patch("pytest_impacted.extensions.importlib.metadata.entry_points")
     def test_with_extension(self, mock_entry_points):

--- a/tests/test_invalidation_integration.py
+++ b/tests/test_invalidation_integration.py
@@ -1,0 +1,122 @@
+"""End-to-end tests for user-supplied invalidation patterns via pytester and a real git repo."""
+
+import subprocess
+import textwrap
+
+import pytest
+
+from pytest_impacted.strategies import clear_dep_tree_cache
+
+
+@pytest.fixture
+def git_project(pytester):
+    """A committed project with a package, two test directories, and non-Python data files.
+
+    Returns a helper that modifies a file in the working tree (unstaged) so that
+    ``unstaged`` git mode sees exactly that change. pytester runs in-process, so
+    the module-name-keyed dependency-tree cache is cleared to keep runs isolated.
+    """
+    clear_dep_tree_cache()
+    pytester.mkpydir("pkg")
+    pytester.makepyfile(**{"pkg/core": "def add(a, b):\n    return a + b\n"})
+    pytester.mkdir("tests")
+    pytester.mkdir("tests/unit")
+    pytester.mkdir("tests/integration")
+    pytester.makepyfile(
+        **{
+            "tests/unit/test_core": "from pkg.core import add\n\ndef test_add():\n    assert add(1, 2) == 3\n",
+            "tests/integration/test_api": "from pkg.core import add\n\ndef test_api():\n    assert add(0, 0) == 0\n",
+        }
+    )
+    pytester.mkdir("config")
+    data_files = {
+        "config/settings.json": "{}",
+        "tests/unit/fixture.json": "{}",
+        "tests/integration/schema.sql": "select 1;",
+    }
+    for rel, content in data_files.items():
+        (pytester.path / rel).write_text(content)
+    (pytester.path / ".gitignore").write_text("__pycache__/\n")
+    pytester.makeini(INI)
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=pytester.path, check=True, capture_output=True)
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("add", ".")
+    git("commit", "-q", "-m", "init")
+
+    def touch(rel: str) -> None:
+        path = pytester.path / rel
+        path.write_text(path.read_text() + "\n")
+
+    pytester.touch = touch
+    yield pytester
+    clear_dep_tree_cache()
+
+
+INI = textwrap.dedent(
+    """
+    [pytest]
+    pythonpath = .
+    impacted_module = pkg
+    impacted_tests_dir = tests
+    """
+)
+
+
+def run(pytester, *args):
+    return pytester.runpytest("--impacted", "-p", "no:cacheprovider", *args)
+
+
+def test_json_change_is_ignored_by_default(git_project):
+    git_project.touch("config/settings.json")
+    run(git_project).assert_outcomes(skipped=2)
+
+
+def test_invalidate_all_runs_every_test(git_project):
+    git_project.touch("config/settings.json")
+    result = run(git_project, "--impacted-invalidate-all=*.json")
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines(["*Invalidation file changes detected*config/settings.json*"])
+
+
+def test_invalidate_all_dir_scoped_glob_does_not_match_elsewhere(git_project):
+    git_project.touch("config/settings.json")
+    run(git_project, "--impacted-invalidate-all=other/*.json").assert_outcomes(skipped=2)
+
+
+def test_invalidate_dir_runs_only_tests_under_changed_file(git_project):
+    git_project.touch("tests/unit/fixture.json")
+    result = run(git_project, "--impacted-invalidate-dir=*.json", "-v")
+    result.assert_outcomes(passed=1, skipped=1)
+    result.stdout.fnmatch_lines(["*tests/unit/test_core.py::test_add PASSED*"])
+
+
+def test_invalidate_dir_outside_test_tree_runs_nothing(git_project):
+    git_project.touch("config/settings.json")
+    run(git_project, "--impacted-invalidate-dir=*.json").assert_outcomes(skipped=2)
+
+
+def test_patterns_from_ini(git_project):
+    git_project.makeini(INI + "impacted_invalidate_all = *.json config/*.yaml\nimpacted_invalidate_dir = *.sql\n")
+    git_project.touch("tests/integration/schema.sql")
+    result = run(git_project, "-v")
+    result.assert_outcomes(passed=1, skipped=1)
+    result.stdout.fnmatch_lines(["*tests/integration/test_api.py::test_api PASSED*"])
+
+    git_project.touch("config/settings.json")
+    run(git_project).assert_outcomes(passed=2)
+
+
+def test_no_dep_files_flag_does_not_disable_invalidation(git_project):
+    """The two features are independent: disabling built-in dep files keeps user rules active."""
+    git_project.touch("config/settings.json")
+    run(git_project, "--impacted-invalidate-all=*.json", "--no-impacted-dep-files").assert_outcomes(passed=2)
+
+
+def test_help_lists_options(pytester):
+    result = pytester.runpytest("--help")
+    result.stdout.fnmatch_lines(["*--impacted-invalidate-all=PATTERN*", "*--impacted-invalidate-dir=PATTERN*"])

--- a/tests/test_invalidation_integration.py
+++ b/tests/test_invalidation_integration.py
@@ -31,8 +31,7 @@ def git_project(pytester):
     pytester.mkdir("config")
     data_files = {
         "config/settings.json": "{}",
-        "tests/unit/fixture.json": "{}",
-        "tests/integration/schema.sql": "select 1;",
+        "config/app.yaml": "key: value\n",
     }
     for rel, content in data_files.items():
         (pytester.path / rel).write_text(content)
@@ -88,26 +87,11 @@ def test_invalidate_all_dir_scoped_glob_does_not_match_elsewhere(git_project):
     run(git_project, "--impacted-invalidate-all=other/*.json").assert_outcomes(skipped=2)
 
 
-def test_invalidate_dir_runs_only_tests_under_changed_file(git_project):
-    git_project.touch("tests/unit/fixture.json")
-    result = run(git_project, "--impacted-invalidate-dir=*.json", "-v")
-    result.assert_outcomes(passed=1, skipped=1)
-    result.stdout.fnmatch_lines(["*tests/unit/test_core.py::test_add PASSED*"])
-
-
-def test_invalidate_dir_outside_test_tree_runs_nothing(git_project):
-    git_project.touch("config/settings.json")
-    run(git_project, "--impacted-invalidate-dir=*.json").assert_outcomes(skipped=2)
-
-
 def test_patterns_from_ini(git_project):
-    git_project.makeini(INI + "impacted_invalidate_all = *.json config/*.yaml\nimpacted_invalidate_dir = *.sql\n")
-    git_project.touch("tests/integration/schema.sql")
-    result = run(git_project, "-v")
-    result.assert_outcomes(passed=1, skipped=1)
-    result.stdout.fnmatch_lines(["*tests/integration/test_api.py::test_api PASSED*"])
-
-    git_project.touch("config/settings.json")
+    """Patterns configured in the ini file are applied, and every one of them counts."""
+    git_project.makeini(INI + "impacted_invalidate_all = *.json config/*.yaml\n")
+    # Matched by the second pattern only — the first (*.json) does not match a .yaml file.
+    git_project.touch("config/app.yaml")
     run(git_project).assert_outcomes(passed=2)
 
 
@@ -119,4 +103,4 @@ def test_no_dep_files_flag_does_not_disable_invalidation(git_project):
 
 def test_help_lists_options(pytester):
     result = pytester.runpytest("--help")
-    result.stdout.fnmatch_lines(["*--impacted-invalidate-all=PATTERN*", "*--impacted-invalidate-dir=PATTERN*"])
+    result.stdout.fnmatch_lines(["*--impacted-invalidate-all=PATTERN*"])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -23,6 +23,8 @@ def cli_options():
         "impacted_base_branch",
         "impacted_tests_dir",
         "no_impacted_dep_files",
+        "impacted_invalidate_all",
+        "impacted_invalidate_dir",
     ]
 
 
@@ -72,6 +74,8 @@ def test_pytest_report_header(pytestconfig):
     pytestconfig.option.impacted_git_mode = GitMode.UNSTAGED
     pytestconfig.option.impacted_base_branch = "main"
     pytestconfig.option.impacted_tests_dir = "tests"
+    pytestconfig.option.impacted_invalidate_all = ["*.json"]
+    pytestconfig.option.impacted_invalidate_dir = ["*.yaml"]
 
     header = pytest_report_header(pytestconfig)
     assert len(header) == 1
@@ -80,6 +84,8 @@ def test_pytest_report_header(pytestconfig):
     assert "impacted_git_mode=unstaged" in header[0]
     assert "impacted_base_branch=main" in header[0]
     assert "impacted_tests_dir=tests" in header[0]
+    assert "impacted_invalidate_all=['*.json']" in header[0]
+    assert "impacted_invalidate_dir=['*.yaml']" in header[0]
     assert "backend=" in header[0]
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -24,7 +24,6 @@ def cli_options():
         "impacted_tests_dir",
         "no_impacted_dep_files",
         "impacted_invalidate_all",
-        "impacted_invalidate_dir",
     ]
 
 
@@ -75,7 +74,6 @@ def test_pytest_report_header(pytestconfig):
     pytestconfig.option.impacted_base_branch = "main"
     pytestconfig.option.impacted_tests_dir = "tests"
     pytestconfig.option.impacted_invalidate_all = ["*.json"]
-    pytestconfig.option.impacted_invalidate_dir = ["*.yaml"]
 
     header = pytest_report_header(pytestconfig)
     assert len(header) == 1
@@ -85,7 +83,6 @@ def test_pytest_report_header(pytestconfig):
     assert "impacted_base_branch=main" in header[0]
     assert "impacted_tests_dir=tests" in header[0]
     assert "impacted_invalidate_all=['*.json']" in header[0]
-    assert "impacted_invalidate_dir=['*.yaml']" in header[0]
     assert "backend=" in header[0]
 
 


### PR DESCRIPTION
Closes #66.

## What

Users can now declare glob patterns for non-Python files (JSON fixtures, SQL schemas, YAML configs, …) that static import analysis cannot see. When a changed file matches, **all** tests are marked impacted — exactly what a `pyproject.toml` change already does, but for files you choose.

```bash
pytest --impacted --impacted-module=my_package --impacted-tests-dir=tests \
    --impacted-invalidate-all='*.json' \
    --impacted-invalidate-all='my_package/config/*.yaml'
```

The option is repeatable, available as an ini setting (`impacted_invalidate_all`), and mirrored on the `impacted-tests` CLI as `--invalidate-all`.

## Design

- New `InvalidationFileImpactStrategy` in `strategies.py`, appended to the default pipeline by `get_default_strategies()` **only when configured**, so existing pipelines are unchanged. It is independent of `--no-impacted-dep-files`, which keeps switching off only the curated built-in list.
- Patterns are globs (not regex), matched by the same right-anchored `PurePosixPath.match` convention the built-in `requirements/*.txt` globs already use, via a new shared `matches_any_glob`. `*.json` matches at any depth; `config/*.json` matches directly under any `config/`; `*` never spans `/`.
- Wired through the existing composition root: `plugin`/`cli` → `build_strategy_with_extensions` → `get_default_strategies`; `api.get_impacted_tests` gains the same kwarg for programmatic parity with `watch_dep_files`.
- Drops a lazy `display.notify` import in `strategies.py` — there was no cycle to dodge.

### Scope change since first review

An earlier revision of this PR also shipped `--impacted-invalidate-dir`, a second "blast radius" level modelled on `conftest.py`: a matching change would impact the tests in **the changed file's own directory and below**.

It has been removed. #66 asked for one thing — files that trigger a full test run — and the companion option read as something it wasn't. "Watch this directory" naturally suggests naming a directory in your source package, but the option keyed off the directory of whichever *changed file* matched. Point it at `my_package/config/*.yaml` and it searches `my_package/config/` for test modules, finds none, and marks nothing. It was only useful for data files sitting *directly beside* the test modules they feed, which is not where most projects put them.

One flag, one meaning. `InvalidationFileImpactStrategy` now takes a single `patterns` sequence and mirrors `DependencyFileImpactStrategy`.

The refactor that extracted the `conftest.py` "directory and below" walk into `find_test_modules_under` is retained — `PytestImpactStrategy` still uses it, and it replaces ~30 lines of nested `try`/`except` and per-module rescanning with four named functions. Its tests moved to `tests/strategies/test_pytest_impact.py`, alongside its only remaining caller.

### One matcher quirk, now documented

With directory-scoped `-all` patterns the way to watch a source tree, users will meet this: `PurePath.match` treats `**` as a plain `*` rather than recursing, so `config/**/*.yaml` matches exactly one level down, not any depth. Called out in `docs/usage.md` and `CLAUDE.md`, and pinned by two parametrized cases so a future matcher change can't silently alter it.

## Tests

- **Unit** — glob matcher semantics (including the `**` behaviour above), the strategy (match / no match / multiple patterns / notification contents), `get_default_strategies()` inclusion rules, extension builder, plugin option registration + report header, the `api` kwarg, and Click CLI pass-through.
- **End-to-end** (`tests/test_invalidation_integration.py`) — pytester driving a real git repo in `unstaged` mode: the default ignores a JSON change, `--impacted-invalidate-all` runs everything and names the triggering file, a directory-scoped glob does not fire elsewhere, ini config works and every configured pattern counts, independence from `--no-impacted-dep-files`, and `--help`.
- Full suite green (377 tests) on both the Rust and pure-Python backends; `pre-commit run --all-files` clean.

## Docs

`README.md`, `docs/usage.md` (the `InvalidationFileImpactStrategy` section with matching rules, both option tables, the `pyproject.toml` example, the pipeline diagram) and `CLAUDE.md` all updated to the single-flag surface.
